### PR TITLE
feat(microsoft): add --microsoft-client-certificate-path for certificate auth

### DIFF
--- a/cartography/cli.py
+++ b/cartography/cli.py
@@ -261,6 +261,7 @@ def _resolve_microsoft_credential_options(
     microsoft_tenant_id: str | None,
     microsoft_client_id: str | None,
     microsoft_client_secret_env_var: str | None,
+    microsoft_client_certificate_path: str | None,
     entra_tenant_id: str | None,
     entra_client_id: str | None,
     entra_client_secret_env_var: str | None,
@@ -278,13 +279,19 @@ def _resolve_microsoft_credential_options(
     )
     entra_values = (entra_tenant_id, entra_client_id, entra_client_secret_env_var)
 
-    has_microsoft_values = any(value is not None for value in microsoft_values)
+    # The certificate path has no legacy Entra alias, but it is still a
+    # Microsoft credential flag for the mixing check below.
+    has_microsoft_values = any(
+        value is not None
+        for value in (*microsoft_values, microsoft_client_certificate_path)
+    )
     has_entra_values = any(value is not None for value in entra_values)
     if has_microsoft_values and has_entra_values:
         raise typer.BadParameter(
             "Cannot mix Microsoft credential flags "
             "(--microsoft-tenant-id, --microsoft-client-id, "
-            "--microsoft-client-secret-env-var) with deprecated Entra "
+            "--microsoft-client-secret-env-var, "
+            "--microsoft-client-certificate-path) with deprecated Entra "
             "credential flags (--entra-tenant-id, --entra-client-id, "
             "--entra-client-secret-env-var). Use the Microsoft flags instead.",
         )
@@ -768,6 +775,20 @@ class CLI:
                 typer.Option(
                     "--microsoft-client-secret-env-var",
                     help="Environment variable name containing Microsoft client secret.",
+                    rich_help_panel=PANEL_MICROSOFT,
+                    hidden=PANEL_MICROSOFT not in visible_panels,
+                ),
+            ] = None,
+            microsoft_client_certificate_path: Annotated[
+                str | None,
+                typer.Option(
+                    "--microsoft-client-certificate-path",
+                    help=(
+                        "Path to a PEM or PKCS#12 file holding the app registration's "
+                        "private key and certificate. Use instead of "
+                        "--microsoft-client-secret-env-var for certificate-based "
+                        "authentication."
+                    ),
                     rich_help_panel=PANEL_MICROSOFT,
                     hidden=PANEL_MICROSOFT not in visible_panels,
                 ),
@@ -2839,6 +2860,7 @@ class CLI:
                 microsoft_tenant_id=microsoft_tenant_id,
                 microsoft_client_id=microsoft_client_id,
                 microsoft_client_secret_env_var=microsoft_client_secret_env_var,
+                microsoft_client_certificate_path=microsoft_client_certificate_path,
                 entra_tenant_id=entra_tenant_id,
                 entra_client_id=entra_client_id,
                 entra_client_secret_env_var=entra_client_secret_env_var,
@@ -3612,6 +3634,7 @@ class CLI:
                 microsoft_tenant_id=microsoft_tenant_id,
                 microsoft_client_id=microsoft_client_id,
                 microsoft_client_secret=microsoft_client_secret,
+                microsoft_client_certificate_path=microsoft_client_certificate_path,
                 aws_requested_syncs=aws_requested_syncs,
                 aws_guardduty_severity_threshold=aws_guardduty_severity_threshold,
                 analysis_job_directory=analysis_job_directory,

--- a/cartography/cli.py
+++ b/cartography/cli.py
@@ -262,6 +262,7 @@ def _resolve_microsoft_credential_options(
     microsoft_client_id: str | None,
     microsoft_client_secret_env_var: str | None,
     microsoft_client_certificate_path: str | None,
+    microsoft_client_certificate_password_env_var: str | None,
     entra_tenant_id: str | None,
     entra_client_id: str | None,
     entra_client_secret_env_var: str | None,
@@ -279,11 +280,15 @@ def _resolve_microsoft_credential_options(
     )
     entra_values = (entra_tenant_id, entra_client_id, entra_client_secret_env_var)
 
-    # The certificate path has no legacy Entra alias, but it is still a
-    # Microsoft credential flag for the mixing check below.
+    # The certificate path and password have no legacy Entra alias, but they
+    # are still Microsoft credential flags for the mixing check below.
     has_microsoft_values = any(
         value is not None
-        for value in (*microsoft_values, microsoft_client_certificate_path)
+        for value in (
+            *microsoft_values,
+            microsoft_client_certificate_path,
+            microsoft_client_certificate_password_env_var,
+        )
     )
     has_entra_values = any(value is not None for value in entra_values)
     if has_microsoft_values and has_entra_values:
@@ -291,7 +296,8 @@ def _resolve_microsoft_credential_options(
             "Cannot mix Microsoft credential flags "
             "(--microsoft-tenant-id, --microsoft-client-id, "
             "--microsoft-client-secret-env-var, "
-            "--microsoft-client-certificate-path) with deprecated Entra "
+            "--microsoft-client-certificate-path, "
+            "--microsoft-client-certificate-password-env-var) with deprecated Entra "
             "credential flags (--entra-tenant-id, --entra-client-id, "
             "--entra-client-secret-env-var). Use the Microsoft flags instead.",
         )
@@ -788,6 +794,20 @@ class CLI:
                         "private key and certificate. Use instead of "
                         "--microsoft-client-secret-env-var for certificate-based "
                         "authentication."
+                    ),
+                    rich_help_panel=PANEL_MICROSOFT,
+                    hidden=PANEL_MICROSOFT not in visible_panels,
+                ),
+            ] = None,
+            microsoft_client_certificate_password_env_var: Annotated[
+                str | None,
+                typer.Option(
+                    "--microsoft-client-certificate-password-env-var",
+                    help=(
+                        "Environment variable name containing the password that "
+                        "protects the private key in "
+                        "--microsoft-client-certificate-path. Omit for an "
+                        "unencrypted certificate file."
                     ),
                     rich_help_panel=PANEL_MICROSOFT,
                     hidden=PANEL_MICROSOFT not in visible_panels,
@@ -2861,6 +2881,9 @@ class CLI:
                 microsoft_client_id=microsoft_client_id,
                 microsoft_client_secret_env_var=microsoft_client_secret_env_var,
                 microsoft_client_certificate_path=microsoft_client_certificate_path,
+                microsoft_client_certificate_password_env_var=(
+                    microsoft_client_certificate_password_env_var
+                ),
                 entra_tenant_id=entra_tenant_id,
                 entra_client_id=entra_client_id,
                 entra_client_secret_env_var=entra_client_secret_env_var,
@@ -2879,6 +2902,21 @@ class CLI:
                 )
                 microsoft_client_secret = os.environ.get(
                     microsoft_client_secret_env_var
+                )
+
+            # Read the Microsoft certificate password, for an encrypted file
+            microsoft_client_certificate_password = None
+            if (
+                microsoft_client_certificate_path
+                and microsoft_client_certificate_password_env_var
+            ):
+                logger.debug(
+                    "Reading certificate password for Microsoft from environment "
+                    "variable %s",
+                    microsoft_client_certificate_password_env_var,
+                )
+                microsoft_client_certificate_password = os.environ.get(
+                    microsoft_client_certificate_password_env_var
                 )
 
             # Read Okta API key
@@ -3635,6 +3673,9 @@ class CLI:
                 microsoft_client_id=microsoft_client_id,
                 microsoft_client_secret=microsoft_client_secret,
                 microsoft_client_certificate_path=microsoft_client_certificate_path,
+                microsoft_client_certificate_password=(
+                    microsoft_client_certificate_password
+                ),
                 aws_requested_syncs=aws_requested_syncs,
                 aws_guardduty_severity_threshold=aws_guardduty_severity_threshold,
                 analysis_job_directory=analysis_job_directory,

--- a/cartography/cli.py
+++ b/cartography/cli.py
@@ -2904,7 +2904,17 @@ class CLI:
                     microsoft_client_secret_env_var
                 )
 
-            # Read the Microsoft certificate password, for an encrypted file
+            # Read the Microsoft certificate password, for an encrypted file. A
+            # password without a certificate would otherwise be dropped silently
+            # and the Microsoft modules skipped as unconfigured.
+            if (
+                microsoft_client_certificate_password_env_var
+                and not microsoft_client_certificate_path
+            ):
+                raise typer.BadParameter(
+                    "--microsoft-client-certificate-password-env-var requires "
+                    "--microsoft-client-certificate-path.",
+                )
             microsoft_client_certificate_password = None
             if (
                 microsoft_client_certificate_path

--- a/cartography/config.py
+++ b/cartography/config.py
@@ -741,7 +741,6 @@ class Config:
         microsoft_tenant_id=None,
         microsoft_client_id=None,
         microsoft_client_secret=None,
-        microsoft_client_certificate_path=None,
         netlify_token=None,
         netlify_account_slug=None,
         netlify_base_url=None,
@@ -759,6 +758,7 @@ class Config:
         gcp_exclude_org_root_projects=False,
         orca_api_endpoint=None,
         orca_api_token=None,
+        microsoft_client_certificate_path=None,
     ):
         self.neo4j_uri = neo4j_uri
         self.neo4j_user = neo4j_user

--- a/cartography/config.py
+++ b/cartography/config.py
@@ -43,7 +43,10 @@ def _resolve_microsoft_credentials_config(
             "`entra_client_secret`). Use the Microsoft fields instead.",
         )
 
-    if microsoft_client_certificate_password and not microsoft_client_certificate_path:
+    if (
+        microsoft_client_certificate_password is not None
+        and not microsoft_client_certificate_path
+    ):
         # A password on its own would be stored and the Microsoft modules then
         # skipped as unconfigured; the CLI refuses the same pair before it gets here.
         raise ValueError(

--- a/cartography/config.py
+++ b/cartography/config.py
@@ -43,6 +43,14 @@ def _resolve_microsoft_credentials_config(
             "`entra_client_secret`). Use the Microsoft fields instead.",
         )
 
+    if microsoft_client_certificate_password and not microsoft_client_certificate_path:
+        # A password on its own would be stored and the Microsoft modules then
+        # skipped as unconfigured; the CLI refuses the same pair before it gets here.
+        raise ValueError(
+            "`microsoft_client_certificate_password` requires "
+            "`microsoft_client_certificate_path`.",
+        )
+
     if has_entra_values:
         logger.warning(
             "DEPRECATED: `entra_tenant_id`/`entra_client_id`/"

--- a/cartography/config.py
+++ b/cartography/config.py
@@ -8,6 +8,7 @@ def _resolve_microsoft_credentials_config(
     microsoft_tenant_id: str | None,
     microsoft_client_id: str | None,
     microsoft_client_secret: str | None,
+    microsoft_client_certificate_path: str | None,
     entra_tenant_id: str | None,
     entra_client_id: str | None,
     entra_client_secret: str | None,
@@ -19,13 +20,19 @@ def _resolve_microsoft_credentials_config(
     )
     entra_values = (entra_tenant_id, entra_client_id, entra_client_secret)
 
-    has_microsoft_values = any(value is not None for value in microsoft_values)
+    # The certificate path has no legacy Entra alias, but it is still a
+    # Microsoft credential field for the mixing check below.
+    has_microsoft_values = any(
+        value is not None
+        for value in (*microsoft_values, microsoft_client_certificate_path)
+    )
     has_entra_values = any(value is not None for value in entra_values)
     if has_microsoft_values and has_entra_values:
         raise ValueError(
             "Cannot mix Microsoft credential config fields "
             "(`microsoft_tenant_id`, `microsoft_client_id`, "
-            "`microsoft_client_secret`) with deprecated Entra credential "
+            "`microsoft_client_secret`, `microsoft_client_certificate_path`) "
+            "with deprecated Entra credential "
             "config fields (`entra_tenant_id`, `entra_client_id`, "
             "`entra_client_secret`). Use the Microsoft fields instead.",
         )
@@ -142,6 +149,8 @@ class Config:
     :param microsoft_client_id: Client Id for connecting to Microsoft Graph via Service Principal Authentication. Optional.
     :type microsoft_client_secret: str
     :param microsoft_client_secret: Client Secret for connecting to Microsoft Graph via Service Principal Authentication. Optional.
+    :type microsoft_client_certificate_path: str
+    :param microsoft_client_certificate_path: Path to a PEM or PKCS#12 file holding the app registration's private key and certificate, for certificate-based Service Principal Authentication instead of a client secret. Optional.
     :type entra_tenant_id: str
     :param entra_tenant_id: DEPRECATED compatibility alias for microsoft_tenant_id. Optional.
     :type entra_client_id: str
@@ -732,6 +741,7 @@ class Config:
         microsoft_tenant_id=None,
         microsoft_client_id=None,
         microsoft_client_secret=None,
+        microsoft_client_certificate_path=None,
         netlify_token=None,
         netlify_account_slug=None,
         netlify_base_url=None,
@@ -789,10 +799,12 @@ class Config:
             microsoft_tenant_id=microsoft_tenant_id,
             microsoft_client_id=microsoft_client_id,
             microsoft_client_secret=microsoft_client_secret,
+            microsoft_client_certificate_path=microsoft_client_certificate_path,
             entra_tenant_id=entra_tenant_id,
             entra_client_id=entra_client_id,
             entra_client_secret=entra_client_secret,
         )
+        self.microsoft_client_certificate_path = microsoft_client_certificate_path
         # DEPRECATED: constructor-time compatibility snapshots for legacy Entra
         # config names. Later assignments do not propagate to microsoft_*.
         # Remove in v1.0.0.

--- a/cartography/config.py
+++ b/cartography/config.py
@@ -9,6 +9,7 @@ def _resolve_microsoft_credentials_config(
     microsoft_client_id: str | None,
     microsoft_client_secret: str | None,
     microsoft_client_certificate_path: str | None,
+    microsoft_client_certificate_password: str | None,
     entra_tenant_id: str | None,
     entra_client_id: str | None,
     entra_client_secret: str | None,
@@ -20,18 +21,23 @@ def _resolve_microsoft_credentials_config(
     )
     entra_values = (entra_tenant_id, entra_client_id, entra_client_secret)
 
-    # The certificate path has no legacy Entra alias, but it is still a
-    # Microsoft credential field for the mixing check below.
+    # The certificate path and password have no legacy Entra alias, but they
+    # are still Microsoft credential fields for the mixing check below.
     has_microsoft_values = any(
         value is not None
-        for value in (*microsoft_values, microsoft_client_certificate_path)
+        for value in (
+            *microsoft_values,
+            microsoft_client_certificate_path,
+            microsoft_client_certificate_password,
+        )
     )
     has_entra_values = any(value is not None for value in entra_values)
     if has_microsoft_values and has_entra_values:
         raise ValueError(
             "Cannot mix Microsoft credential config fields "
             "(`microsoft_tenant_id`, `microsoft_client_id`, "
-            "`microsoft_client_secret`, `microsoft_client_certificate_path`) "
+            "`microsoft_client_secret`, `microsoft_client_certificate_path`, "
+            "`microsoft_client_certificate_password`) "
             "with deprecated Entra credential "
             "config fields (`entra_tenant_id`, `entra_client_id`, "
             "`entra_client_secret`). Use the Microsoft fields instead.",
@@ -151,6 +157,8 @@ class Config:
     :param microsoft_client_secret: Client Secret for connecting to Microsoft Graph via Service Principal Authentication. Optional.
     :type microsoft_client_certificate_path: str
     :param microsoft_client_certificate_path: Path to a PEM or PKCS#12 file holding the app registration's private key and certificate, for certificate-based Service Principal Authentication instead of a client secret. Optional.
+    :type microsoft_client_certificate_password: str
+    :param microsoft_client_certificate_password: Password protecting the private key in microsoft_client_certificate_path, for an encrypted PEM or PFX file. Optional; omit for an unencrypted file.
     :type entra_tenant_id: str
     :param entra_tenant_id: DEPRECATED compatibility alias for microsoft_tenant_id. Optional.
     :type entra_client_id: str
@@ -759,6 +767,7 @@ class Config:
         orca_api_endpoint=None,
         orca_api_token=None,
         microsoft_client_certificate_path=None,
+        microsoft_client_certificate_password=None,
     ):
         self.neo4j_uri = neo4j_uri
         self.neo4j_user = neo4j_user
@@ -800,11 +809,15 @@ class Config:
             microsoft_client_id=microsoft_client_id,
             microsoft_client_secret=microsoft_client_secret,
             microsoft_client_certificate_path=microsoft_client_certificate_path,
+            microsoft_client_certificate_password=microsoft_client_certificate_password,
             entra_tenant_id=entra_tenant_id,
             entra_client_id=entra_client_id,
             entra_client_secret=entra_client_secret,
         )
         self.microsoft_client_certificate_path = microsoft_client_certificate_path
+        self.microsoft_client_certificate_password = (
+            microsoft_client_certificate_password
+        )
         # DEPRECATED: constructor-time compatibility snapshots for legacy Entra
         # config names. Later assignments do not propagate to microsoft_*.
         # Remove in v1.0.0.

--- a/cartography/intel/microsoft/__init__.py
+++ b/cartography/intel/microsoft/__init__.py
@@ -24,7 +24,9 @@ def start_microsoft_ingestion(neo4j_session: neo4j.Session, config: Config) -> N
     if (
         not config.microsoft_tenant_id
         or not config.microsoft_client_id
-        or not config.microsoft_client_secret
+        or not (
+            config.microsoft_client_secret or config.microsoft_client_certificate_path
+        )
     ):
         logger.info(
             "Microsoft import is not configured - skipping this module. "

--- a/cartography/intel/microsoft/credentials.py
+++ b/cartography/intel/microsoft/credentials.py
@@ -40,14 +40,14 @@ def make_credential(
         registered application's private key and certificate (PKCS#12 needs
         azure-identity >= 1.7.0, which pyproject pins)
     :param client_certificate_password: Password protecting the private key in
-        that file, for an encrypted PEM or PFX export. Omit for an unencrypted
-        file.
+        that file, for an encrypted PEM or PFX export (an empty string is a
+        password too: some PFX exports carry one). Omit for an unencrypted file.
     :return: A credential the Graph clients can authenticate with
     :raises ValueError: if neither a client secret nor a certificate is given
     """
     if client_certificate_path:
         kwargs: dict[str, str] = {}
-        if client_certificate_password:
+        if client_certificate_password is not None:
             kwargs["password"] = client_certificate_password
         return CertificateCredential(
             tenant_id=tenant_id,

--- a/cartography/intel/microsoft/credentials.py
+++ b/cartography/intel/microsoft/credentials.py
@@ -24,6 +24,7 @@ def make_credential(
     client_secret: str | None = None,
     *,
     client_certificate_path: str | None = None,
+    client_certificate_password: str | None = None,
 ) -> TokenCredential:
     """
     Build the credential used to authenticate against Microsoft Graph.
@@ -36,15 +37,23 @@ def make_credential(
     :param client_id: Application (client) ID of the registered application
     :param client_secret: Client secret of the registered application
     :param client_certificate_path: Path to a PEM or PKCS#12 file holding the
-        registered application's private key and certificate
+        registered application's private key and certificate (PKCS#12 needs
+        azure-identity >= 1.7.0, which pyproject pins)
+    :param client_certificate_password: Password protecting the private key in
+        that file, for an encrypted PEM or PFX export. Omit for an unencrypted
+        file.
     :return: A credential the Graph clients can authenticate with
     :raises ValueError: if neither a client secret nor a certificate is given
     """
     if client_certificate_path:
+        kwargs: dict[str, str] = {}
+        if client_certificate_password:
+            kwargs["password"] = client_certificate_password
         return CertificateCredential(
             tenant_id=tenant_id,
             client_id=client_id,
             certificate_path=client_certificate_path,
+            **kwargs,
         )
     if client_secret:
         return ClientSecretCredential(

--- a/cartography/intel/microsoft/credentials.py
+++ b/cartography/intel/microsoft/credentials.py
@@ -14,24 +14,44 @@ substitute the credential.
 """
 
 from azure.core.credentials import TokenCredential
+from azure.identity import CertificateCredential
 from azure.identity import ClientSecretCredential
 
 
 def make_credential(
     tenant_id: str,
     client_id: str,
-    client_secret: str,
+    client_secret: str | None = None,
+    *,
+    client_certificate_path: str | None = None,
 ) -> TokenCredential:
     """
     Build the credential used to authenticate against Microsoft Graph.
 
+    The app registration authenticates with either a client secret or a
+    certificate. Pass exactly one; a certificate takes precedence when both are
+    given because a secret is never needed alongside it.
+
     :param tenant_id: Microsoft Entra tenant ID
     :param client_id: Application (client) ID of the registered application
     :param client_secret: Client secret of the registered application
+    :param client_certificate_path: Path to a PEM or PKCS#12 file holding the
+        registered application's private key and certificate
     :return: A credential the Graph clients can authenticate with
+    :raises ValueError: if neither a client secret nor a certificate is given
     """
-    return ClientSecretCredential(
-        tenant_id=tenant_id,
-        client_id=client_id,
-        client_secret=client_secret,
+    if client_certificate_path:
+        return CertificateCredential(
+            tenant_id=tenant_id,
+            client_id=client_id,
+            certificate_path=client_certificate_path,
+        )
+    if client_secret:
+        return ClientSecretCredential(
+            tenant_id=tenant_id,
+            client_id=client_id,
+            client_secret=client_secret,
+        )
+    raise ValueError(
+        "Microsoft credentials need a client secret or a client certificate path",
     )

--- a/cartography/intel/microsoft/entra/__init__.py
+++ b/cartography/intel/microsoft/entra/__init__.py
@@ -72,6 +72,9 @@ def start_entra_ingestion(neo4j_session: neo4j.Session, config: Config) -> None:
     Must run before Intune ingestion, as Intune nodes relate back to Entra
     users, groups, and tenants.
 
+    Authenticates with config.microsoft_tenant_id / client_id and either
+    client_secret or client_certificate_path.
+
     :param neo4j_session: Neo4J session for database interface
     :param config: A cartography.config object
     :return: None

--- a/cartography/intel/microsoft/entra/__init__.py
+++ b/cartography/intel/microsoft/entra/__init__.py
@@ -35,6 +35,7 @@ async def sync_tenant(
     client_secret: str | None,
     update_tag: int,
     client_certificate_path: str | None = None,
+    client_certificate_password: str | None = None,
 ) -> None:
     """
     Sync tenant information as a prerequisite for all other Entra resource syncs.
@@ -45,6 +46,8 @@ async def sync_tenant(
     :param client_secret: Azure application client secret
     :param client_certificate_path: Path to a PEM or PKCS#12 file holding the
         application's private key and certificate, used instead of the secret
+    :param client_certificate_password: Password protecting the private key in
+        that file, when the file is encrypted
     :param update_tag: Update tag for tracking data freshness
     """
     credential = credentials.make_credential(
@@ -52,6 +55,7 @@ async def sync_tenant(
         client_id,
         client_secret,
         client_certificate_path=client_certificate_path,
+        client_certificate_password=client_certificate_password,
     )
     client = GraphServiceClient(
         credential, scopes=["https://graph.microsoft.com/.default"]
@@ -73,7 +77,8 @@ def start_entra_ingestion(neo4j_session: neo4j.Session, config: Config) -> None:
     users, groups, and tenants.
 
     Authenticates with config.microsoft_tenant_id / client_id and either
-    client_secret or client_certificate_path.
+    client_secret or client_certificate_path (plus client_certificate_password
+    when the certificate file is encrypted).
 
     :param neo4j_session: Neo4J session for database interface
     :param config: A cartography.config object
@@ -83,6 +88,7 @@ def start_entra_ingestion(neo4j_session: neo4j.Session, config: Config) -> None:
     client_id = config.microsoft_client_id
     client_secret = config.microsoft_client_secret
     client_certificate_path = config.microsoft_client_certificate_path
+    client_certificate_password = config.microsoft_client_certificate_password
     if not tenant_id or not client_id or not (client_secret or client_certificate_path):
         logger.info(
             "Entra import is not configured - skipping this module. "
@@ -104,6 +110,7 @@ def start_entra_ingestion(neo4j_session: neo4j.Session, config: Config) -> None:
             client_secret,
             config.update_tag,
             client_certificate_path=client_certificate_path,
+            client_certificate_password=client_certificate_password,
         )
 
         # Run user sync
@@ -115,6 +122,7 @@ def start_entra_ingestion(neo4j_session: neo4j.Session, config: Config) -> None:
             config.update_tag,
             common_job_parameters,
             client_certificate_path=client_certificate_path,
+            client_certificate_password=client_certificate_password,
         )
 
         # Run group sync
@@ -126,6 +134,7 @@ def start_entra_ingestion(neo4j_session: neo4j.Session, config: Config) -> None:
             config.update_tag,
             common_job_parameters,
             client_certificate_path=client_certificate_path,
+            client_certificate_password=client_certificate_password,
         )
 
         # Run OU sync
@@ -137,6 +146,7 @@ def start_entra_ingestion(neo4j_session: neo4j.Session, config: Config) -> None:
             config.update_tag,
             common_job_parameters,
             client_certificate_path=client_certificate_path,
+            client_certificate_password=client_certificate_password,
         )
 
         # Run application sync
@@ -148,6 +158,7 @@ def start_entra_ingestion(neo4j_session: neo4j.Session, config: Config) -> None:
             config.update_tag,
             common_job_parameters,
             client_certificate_path=client_certificate_path,
+            client_certificate_password=client_certificate_password,
         )
 
         # Run service principals sync
@@ -159,6 +170,7 @@ def start_entra_ingestion(neo4j_session: neo4j.Session, config: Config) -> None:
             config.update_tag,
             common_job_parameters,
             client_certificate_path=client_certificate_path,
+            client_certificate_password=client_certificate_password,
         )
 
         # Run app role assignments sync
@@ -170,6 +182,7 @@ def start_entra_ingestion(neo4j_session: neo4j.Session, config: Config) -> None:
             config.update_tag,
             common_job_parameters,
             client_certificate_path=client_certificate_path,
+            client_certificate_password=client_certificate_password,
         )
 
         # Run directory role sync (definitions + assignments).
@@ -187,6 +200,7 @@ def start_entra_ingestion(neo4j_session: neo4j.Session, config: Config) -> None:
                 config.update_tag,
                 common_job_parameters,
                 client_certificate_path=client_certificate_path,
+                client_certificate_password=client_certificate_password,
             )
         except APIError as e:
             if e.response_status_code in (401, 403):

--- a/cartography/intel/microsoft/entra/__init__.py
+++ b/cartography/intel/microsoft/entra/__init__.py
@@ -32,8 +32,9 @@ async def sync_tenant(
     neo4j_session: neo4j.Session,
     tenant_id: str,
     client_id: str,
-    client_secret: str,
+    client_secret: str | None,
     update_tag: int,
+    client_certificate_path: str | None = None,
 ) -> None:
     """
     Sync tenant information as a prerequisite for all other Entra resource syncs.
@@ -42,9 +43,16 @@ async def sync_tenant(
     :param tenant_id: Entra tenant ID
     :param client_id: Azure application client ID
     :param client_secret: Azure application client secret
+    :param client_certificate_path: Path to a PEM or PKCS#12 file holding the
+        application's private key and certificate, used instead of the secret
     :param update_tag: Update tag for tracking data freshness
     """
-    credential = credentials.make_credential(tenant_id, client_id, client_secret)
+    credential = credentials.make_credential(
+        tenant_id,
+        client_id,
+        client_secret,
+        client_certificate_path=client_certificate_path,
+    )
     client = GraphServiceClient(
         credential, scopes=["https://graph.microsoft.com/.default"]
     )
@@ -71,7 +79,8 @@ def start_entra_ingestion(neo4j_session: neo4j.Session, config: Config) -> None:
     tenant_id = config.microsoft_tenant_id
     client_id = config.microsoft_client_id
     client_secret = config.microsoft_client_secret
-    if not tenant_id or not client_id or not client_secret:
+    client_certificate_path = config.microsoft_client_certificate_path
+    if not tenant_id or not client_id or not (client_secret or client_certificate_path):
         logger.info(
             "Entra import is not configured - skipping this module. "
             "See docs to configure.",
@@ -91,6 +100,7 @@ def start_entra_ingestion(neo4j_session: neo4j.Session, config: Config) -> None:
             client_id,
             client_secret,
             config.update_tag,
+            client_certificate_path=client_certificate_path,
         )
 
         # Run user sync
@@ -101,6 +111,7 @@ def start_entra_ingestion(neo4j_session: neo4j.Session, config: Config) -> None:
             client_secret,
             config.update_tag,
             common_job_parameters,
+            client_certificate_path=client_certificate_path,
         )
 
         # Run group sync
@@ -111,6 +122,7 @@ def start_entra_ingestion(neo4j_session: neo4j.Session, config: Config) -> None:
             client_secret,
             config.update_tag,
             common_job_parameters,
+            client_certificate_path=client_certificate_path,
         )
 
         # Run OU sync
@@ -121,6 +133,7 @@ def start_entra_ingestion(neo4j_session: neo4j.Session, config: Config) -> None:
             client_secret,
             config.update_tag,
             common_job_parameters,
+            client_certificate_path=client_certificate_path,
         )
 
         # Run application sync
@@ -131,6 +144,7 @@ def start_entra_ingestion(neo4j_session: neo4j.Session, config: Config) -> None:
             client_secret,
             config.update_tag,
             common_job_parameters,
+            client_certificate_path=client_certificate_path,
         )
 
         # Run service principals sync
@@ -141,6 +155,7 @@ def start_entra_ingestion(neo4j_session: neo4j.Session, config: Config) -> None:
             client_secret,
             config.update_tag,
             common_job_parameters,
+            client_certificate_path=client_certificate_path,
         )
 
         # Run app role assignments sync
@@ -151,6 +166,7 @@ def start_entra_ingestion(neo4j_session: neo4j.Session, config: Config) -> None:
             client_secret,
             config.update_tag,
             common_job_parameters,
+            client_certificate_path=client_certificate_path,
         )
 
         # Run directory role sync (definitions + assignments).
@@ -167,6 +183,7 @@ def start_entra_ingestion(neo4j_session: neo4j.Session, config: Config) -> None:
                 client_secret,
                 config.update_tag,
                 common_job_parameters,
+                client_certificate_path=client_certificate_path,
             )
         except APIError as e:
             if e.response_status_code in (401, 403):

--- a/cartography/intel/microsoft/entra/app_role_assignments.py
+++ b/cartography/intel/microsoft/entra/app_role_assignments.py
@@ -247,9 +247,10 @@ async def sync_app_role_assignments(
     neo4j_session: neo4j.Session,
     tenant_id: str,
     client_id: str,
-    client_secret: str,
+    client_secret: str | None,
     update_tag: int,
     common_job_parameters: dict[str, Any],
+    client_certificate_path: str | None = None,
 ) -> None:
     """
     Sync Entra app role assignments to the graph.
@@ -258,11 +259,18 @@ async def sync_app_role_assignments(
     :param tenant_id: Entra tenant ID
     :param client_id: Azure application client ID
     :param client_secret: Azure application client secret
+    :param client_certificate_path: Path to a PEM or PKCS#12 file holding the
+        application's private key and certificate, used instead of the secret
     :param update_tag: Update tag for tracking data freshness
     :param common_job_parameters: Common job parameters for cleanup
     """
     # Create credentials and client
-    credential = credentials.make_credential(tenant_id, client_id, client_secret)
+    credential = credentials.make_credential(
+        tenant_id,
+        client_id,
+        client_secret,
+        client_certificate_path=client_certificate_path,
+    )
 
     client = GraphServiceClient(
         credential,

--- a/cartography/intel/microsoft/entra/app_role_assignments.py
+++ b/cartography/intel/microsoft/entra/app_role_assignments.py
@@ -251,6 +251,7 @@ async def sync_app_role_assignments(
     update_tag: int,
     common_job_parameters: dict[str, Any],
     client_certificate_path: str | None = None,
+    client_certificate_password: str | None = None,
 ) -> None:
     """
     Sync Entra app role assignments to the graph.
@@ -261,6 +262,8 @@ async def sync_app_role_assignments(
     :param client_secret: Azure application client secret
     :param client_certificate_path: Path to a PEM or PKCS#12 file holding the
         application's private key and certificate, used instead of the secret
+    :param client_certificate_password: Password protecting the private key in
+        that file, when the file is encrypted
     :param update_tag: Update tag for tracking data freshness
     :param common_job_parameters: Common job parameters for cleanup
     """
@@ -270,6 +273,7 @@ async def sync_app_role_assignments(
         client_id,
         client_secret,
         client_certificate_path=client_certificate_path,
+        client_certificate_password=client_certificate_password,
     )
 
     client = GraphServiceClient(

--- a/cartography/intel/microsoft/entra/applications.py
+++ b/cartography/intel/microsoft/entra/applications.py
@@ -140,9 +140,10 @@ async def sync_entra_applications(
     neo4j_session: neo4j.Session,
     tenant_id: str,
     client_id: str,
-    client_secret: str,
+    client_secret: str | None,
     update_tag: int,
     common_job_parameters: dict[str, Any],
+    client_certificate_path: str | None = None,
 ) -> None:
     """
     Sync Entra applications and their app role assignments to the graph.
@@ -151,11 +152,18 @@ async def sync_entra_applications(
     :param tenant_id: Entra tenant ID
     :param client_id: Azure application client ID
     :param client_secret: Azure application client secret
+    :param client_certificate_path: Path to a PEM or PKCS#12 file holding the
+        application's private key and certificate, used instead of the secret
     :param update_tag: Update tag for tracking data freshness
     :param common_job_parameters: Common job parameters containing UPDATE_TAG and TENANT_ID
     """
     # Create credentials and client
-    credential = credentials.make_credential(tenant_id, client_id, client_secret)
+    credential = credentials.make_credential(
+        tenant_id,
+        client_id,
+        client_secret,
+        client_certificate_path=client_certificate_path,
+    )
 
     client = GraphServiceClient(
         credential,

--- a/cartography/intel/microsoft/entra/applications.py
+++ b/cartography/intel/microsoft/entra/applications.py
@@ -144,6 +144,7 @@ async def sync_entra_applications(
     update_tag: int,
     common_job_parameters: dict[str, Any],
     client_certificate_path: str | None = None,
+    client_certificate_password: str | None = None,
 ) -> None:
     """
     Sync Entra applications and their app role assignments to the graph.
@@ -154,6 +155,8 @@ async def sync_entra_applications(
     :param client_secret: Azure application client secret
     :param client_certificate_path: Path to a PEM or PKCS#12 file holding the
         application's private key and certificate, used instead of the secret
+    :param client_certificate_password: Password protecting the private key in
+        that file, when the file is encrypted
     :param update_tag: Update tag for tracking data freshness
     :param common_job_parameters: Common job parameters containing UPDATE_TAG and TENANT_ID
     """
@@ -163,6 +166,7 @@ async def sync_entra_applications(
         client_id,
         client_secret,
         client_certificate_path=client_certificate_path,
+        client_certificate_password=client_certificate_password,
     )
 
     client = GraphServiceClient(

--- a/cartography/intel/microsoft/entra/directory_roles.py
+++ b/cartography/intel/microsoft/entra/directory_roles.py
@@ -145,9 +145,10 @@ async def sync_entra_directory_roles(
     neo4j_session: neo4j.Session,
     tenant_id: str,
     client_id: str,
-    client_secret: str,
+    client_secret: str | None,
     update_tag: int,
     common_job_parameters: dict[str, Any],
+    client_certificate_path: str | None = None,
 ) -> None:
     """
     Sync Entra directory role definitions and role assignments to the graph.
@@ -156,10 +157,17 @@ async def sync_entra_directory_roles(
     :param tenant_id: Entra tenant ID
     :param client_id: Azure application client ID
     :param client_secret: Azure application client secret
+    :param client_certificate_path: Path to a PEM or PKCS#12 file holding the
+        application's private key and certificate, used instead of the secret
     :param update_tag: Update tag for tracking data freshness
     :param common_job_parameters: Common job parameters for cleanup
     """
-    credential = credentials.make_credential(tenant_id, client_id, client_secret)
+    credential = credentials.make_credential(
+        tenant_id,
+        client_id,
+        client_secret,
+        client_certificate_path=client_certificate_path,
+    )
     client = GraphServiceClient(
         credential,
         scopes=["https://graph.microsoft.com/.default"],

--- a/cartography/intel/microsoft/entra/directory_roles.py
+++ b/cartography/intel/microsoft/entra/directory_roles.py
@@ -149,6 +149,7 @@ async def sync_entra_directory_roles(
     update_tag: int,
     common_job_parameters: dict[str, Any],
     client_certificate_path: str | None = None,
+    client_certificate_password: str | None = None,
 ) -> None:
     """
     Sync Entra directory role definitions and role assignments to the graph.
@@ -159,6 +160,8 @@ async def sync_entra_directory_roles(
     :param client_secret: Azure application client secret
     :param client_certificate_path: Path to a PEM or PKCS#12 file holding the
         application's private key and certificate, used instead of the secret
+    :param client_certificate_password: Password protecting the private key in
+        that file, when the file is encrypted
     :param update_tag: Update tag for tracking data freshness
     :param common_job_parameters: Common job parameters for cleanup
     """
@@ -167,6 +170,7 @@ async def sync_entra_directory_roles(
         client_id,
         client_secret,
         client_certificate_path=client_certificate_path,
+        client_certificate_password=client_certificate_password,
     )
     client = GraphServiceClient(
         credential,

--- a/cartography/intel/microsoft/entra/groups.py
+++ b/cartography/intel/microsoft/entra/groups.py
@@ -135,12 +135,18 @@ async def sync_entra_groups(
     neo4j_session: neo4j.Session,
     tenant_id: str,
     client_id: str,
-    client_secret: str,
+    client_secret: str | None,
     update_tag: int,
     common_job_parameters: dict[str, Any],
+    client_certificate_path: str | None = None,
 ) -> None:
     """Sync Entra groups."""
-    credential = credentials.make_credential(tenant_id, client_id, client_secret)
+    credential = credentials.make_credential(
+        tenant_id,
+        client_id,
+        client_secret,
+        client_certificate_path=client_certificate_path,
+    )
     client = GraphServiceClient(
         credential, scopes=["https://graph.microsoft.com/.default"]
     )

--- a/cartography/intel/microsoft/entra/groups.py
+++ b/cartography/intel/microsoft/entra/groups.py
@@ -139,6 +139,7 @@ async def sync_entra_groups(
     update_tag: int,
     common_job_parameters: dict[str, Any],
     client_certificate_path: str | None = None,
+    client_certificate_password: str | None = None,
 ) -> None:
     """Sync Entra groups."""
     credential = credentials.make_credential(
@@ -146,6 +147,7 @@ async def sync_entra_groups(
         client_id,
         client_secret,
         client_certificate_path=client_certificate_path,
+        client_certificate_password=client_certificate_password,
     )
     client = GraphServiceClient(
         credential, scopes=["https://graph.microsoft.com/.default"]

--- a/cartography/intel/microsoft/entra/ou.py
+++ b/cartography/intel/microsoft/entra/ou.py
@@ -100,6 +100,7 @@ async def sync_entra_ous(
     update_tag: int,
     common_job_parameters: dict[str, Any],
     client_certificate_path: str | None = None,
+    client_certificate_password: str | None = None,
 ) -> None:
     """
     Sync Entra OUs
@@ -110,6 +111,7 @@ async def sync_entra_ous(
         client_id,
         client_secret,
         client_certificate_path=client_certificate_path,
+        client_certificate_password=client_certificate_password,
     )
     client = GraphServiceClient(
         credential, scopes=["https://graph.microsoft.com/.default"]

--- a/cartography/intel/microsoft/entra/ou.py
+++ b/cartography/intel/microsoft/entra/ou.py
@@ -96,15 +96,21 @@ async def sync_entra_ous(
     neo4j_session: neo4j.Session,
     tenant_id: str,
     client_id: str,
-    client_secret: str,
+    client_secret: str | None,
     update_tag: int,
     common_job_parameters: dict[str, Any],
+    client_certificate_path: str | None = None,
 ) -> None:
     """
     Sync Entra OUs
     """
     # Initialize Graph client
-    credential = credentials.make_credential(tenant_id, client_id, client_secret)
+    credential = credentials.make_credential(
+        tenant_id,
+        client_id,
+        client_secret,
+        client_certificate_path=client_certificate_path,
+    )
     client = GraphServiceClient(
         credential, scopes=["https://graph.microsoft.com/.default"]
     )

--- a/cartography/intel/microsoft/entra/service_principals.py
+++ b/cartography/intel/microsoft/entra/service_principals.py
@@ -175,9 +175,10 @@ async def sync_service_principals(
     neo4j_session: neo4j.Session,
     tenant_id: str,
     client_id: str,
-    client_secret: str,
+    client_secret: str | None,
     update_tag: int,
     common_job_parameters: dict[str, Any],
+    client_certificate_path: str | None = None,
 ) -> None:
     """
     Sync Entra service principals to the graph.
@@ -186,11 +187,18 @@ async def sync_service_principals(
     :param tenant_id: Entra tenant ID
     :param client_id: Azure application client ID
     :param client_secret: Azure application client secret
+    :param client_certificate_path: Path to a PEM or PKCS#12 file holding the
+        application's private key and certificate, used instead of the secret
     :param update_tag: Update tag for tracking data freshness
     :param common_job_parameters: Common job parameters for cleanup
     """
     # Create credentials and client
-    credential = credentials.make_credential(tenant_id, client_id, client_secret)
+    credential = credentials.make_credential(
+        tenant_id,
+        client_id,
+        client_secret,
+        client_certificate_path=client_certificate_path,
+    )
 
     client = GraphServiceClient(
         credential,

--- a/cartography/intel/microsoft/entra/service_principals.py
+++ b/cartography/intel/microsoft/entra/service_principals.py
@@ -179,6 +179,7 @@ async def sync_service_principals(
     update_tag: int,
     common_job_parameters: dict[str, Any],
     client_certificate_path: str | None = None,
+    client_certificate_password: str | None = None,
 ) -> None:
     """
     Sync Entra service principals to the graph.
@@ -189,6 +190,8 @@ async def sync_service_principals(
     :param client_secret: Azure application client secret
     :param client_certificate_path: Path to a PEM or PKCS#12 file holding the
         application's private key and certificate, used instead of the secret
+    :param client_certificate_password: Password protecting the private key in
+        that file, when the file is encrypted
     :param update_tag: Update tag for tracking data freshness
     :param common_job_parameters: Common job parameters for cleanup
     """
@@ -198,6 +201,7 @@ async def sync_service_principals(
         client_id,
         client_secret,
         client_certificate_path=client_certificate_path,
+        client_certificate_password=client_certificate_password,
     )
 
     client = GraphServiceClient(

--- a/cartography/intel/microsoft/entra/users.py
+++ b/cartography/intel/microsoft/entra/users.py
@@ -226,6 +226,7 @@ async def sync_entra_users(
     update_tag: int,
     common_job_parameters: dict[str, Any],
     client_certificate_path: str | None = None,
+    client_certificate_password: str | None = None,
 ) -> None:
     """
     Sync Entra users and tenant information
@@ -235,6 +236,8 @@ async def sync_entra_users(
     :param client_secret: Entra application client secret
     :param client_certificate_path: Path to a PEM or PKCS#12 file holding the
         application's private key and certificate, used instead of the secret
+    :param client_certificate_password: Password protecting the private key in
+        that file, when the file is encrypted
     :param update_tag: Timestamp used to determine data freshness
     :param common_job_parameters: dict of other job parameters to carry to sub-jobs
     :return: None
@@ -245,6 +248,7 @@ async def sync_entra_users(
         client_id,
         client_secret,
         client_certificate_path=client_certificate_path,
+        client_certificate_password=client_certificate_password,
     )
     client = GraphServiceClient(
         credential, scopes=["https://graph.microsoft.com/.default"]

--- a/cartography/intel/microsoft/entra/users.py
+++ b/cartography/intel/microsoft/entra/users.py
@@ -222,9 +222,10 @@ async def sync_entra_users(
     neo4j_session: neo4j.Session,
     tenant_id: str,
     client_id: str,
-    client_secret: str,
+    client_secret: str | None,
     update_tag: int,
     common_job_parameters: dict[str, Any],
+    client_certificate_path: str | None = None,
 ) -> None:
     """
     Sync Entra users and tenant information
@@ -232,12 +233,19 @@ async def sync_entra_users(
     :param tenant_id: Entra tenant ID
     :param client_id: Entra application client ID
     :param client_secret: Entra application client secret
+    :param client_certificate_path: Path to a PEM or PKCS#12 file holding the
+        application's private key and certificate, used instead of the secret
     :param update_tag: Timestamp used to determine data freshness
     :param common_job_parameters: dict of other job parameters to carry to sub-jobs
     :return: None
     """
     # Initialize Graph client
-    credential = credentials.make_credential(tenant_id, client_id, client_secret)
+    credential = credentials.make_credential(
+        tenant_id,
+        client_id,
+        client_secret,
+        client_certificate_path=client_certificate_path,
+    )
     client = GraphServiceClient(
         credential, scopes=["https://graph.microsoft.com/.default"]
     )

--- a/cartography/intel/microsoft/intune/__init__.py
+++ b/cartography/intel/microsoft/intune/__init__.py
@@ -29,7 +29,8 @@ def start_intune_ingestion(neo4j_session: neo4j.Session, config: Config) -> None
     as Intune nodes relate back to Entra users, groups, and tenants.
 
     Uses the same Microsoft Graph credentials as the Entra sync
-    (config.microsoft_tenant_id / client_id / client_secret).
+    (config.microsoft_tenant_id / client_id, and either client_secret or
+    client_certificate_path).
 
     :param neo4j_session: Neo4J session for database interface
     :param config: A cartography.config object

--- a/cartography/intel/microsoft/intune/__init__.py
+++ b/cartography/intel/microsoft/intune/__init__.py
@@ -38,7 +38,8 @@ def start_intune_ingestion(neo4j_session: neo4j.Session, config: Config) -> None
     tenant_id = config.microsoft_tenant_id
     client_id = config.microsoft_client_id
     client_secret = config.microsoft_client_secret
-    if not tenant_id or not client_id or not client_secret:
+    client_certificate_path = config.microsoft_client_certificate_path
+    if not tenant_id or not client_id or not (client_secret or client_certificate_path):
         logger.info(
             "Intune import is not configured - skipping this module. "
             "See docs to configure.",
@@ -51,7 +52,12 @@ def start_intune_ingestion(neo4j_session: neo4j.Session, config: Config) -> None
     }
 
     async def main() -> None:
-        credential = credentials.make_credential(tenant_id, client_id, client_secret)
+        credential = credentials.make_credential(
+            tenant_id,
+            client_id,
+            client_secret,
+            client_certificate_path=client_certificate_path,
+        )
         intune_client = create_graph_service_client(credential)
 
         managed_devices_synced = False

--- a/cartography/intel/microsoft/intune/__init__.py
+++ b/cartography/intel/microsoft/intune/__init__.py
@@ -40,6 +40,7 @@ def start_intune_ingestion(neo4j_session: neo4j.Session, config: Config) -> None
     client_id = config.microsoft_client_id
     client_secret = config.microsoft_client_secret
     client_certificate_path = config.microsoft_client_certificate_path
+    client_certificate_password = config.microsoft_client_certificate_password
     if not tenant_id or not client_id or not (client_secret or client_certificate_path):
         logger.info(
             "Intune import is not configured - skipping this module. "
@@ -58,6 +59,7 @@ def start_intune_ingestion(neo4j_session: neo4j.Session, config: Config) -> None
             client_id,
             client_secret,
             client_certificate_path=client_certificate_path,
+            client_certificate_password=client_certificate_password,
         )
         intune_client = create_graph_service_client(credential)
 

--- a/cartography/intel/microsoft/o365/__init__.py
+++ b/cartography/intel/microsoft/o365/__init__.py
@@ -38,6 +38,7 @@ def start_o365_ingestion(neo4j_session: neo4j.Session, config: Config) -> None:
     client_id = config.microsoft_client_id
     client_secret = config.microsoft_client_secret
     client_certificate_path = config.microsoft_client_certificate_path
+    client_certificate_password = config.microsoft_client_certificate_password
     if not tenant_id or not client_id or not (client_secret or client_certificate_path):
         logger.info(
             "O365 import is not configured - skipping this module. "
@@ -56,6 +57,7 @@ def start_o365_ingestion(neo4j_session: neo4j.Session, config: Config) -> None:
             client_id,
             client_secret,
             client_certificate_path=client_certificate_path,
+            client_certificate_password=client_certificate_password,
         )
         o365_client = create_graph_service_client(credential)
 

--- a/cartography/intel/microsoft/o365/__init__.py
+++ b/cartography/intel/microsoft/o365/__init__.py
@@ -24,7 +24,8 @@ def start_o365_ingestion(neo4j_session: neo4j.Session, config: Config) -> None:
     per-user license assignments).
 
     Requires the same Microsoft Graph credentials used for the main Microsoft
-    module. Needs Organization.Read.All or Directory.Read.All Graph permission
+    module (config.microsoft_tenant_id / client_id, and either client_secret
+    or client_certificate_path). Needs Organization.Read.All or Directory.Read.All Graph permission
     for subscribedSkus, and User.Read.All for per-user assigned licenses.
 
     This sync is optional: if the app registration lacks the required Graph

--- a/cartography/intel/microsoft/o365/__init__.py
+++ b/cartography/intel/microsoft/o365/__init__.py
@@ -36,7 +36,8 @@ def start_o365_ingestion(neo4j_session: neo4j.Session, config: Config) -> None:
     tenant_id = config.microsoft_tenant_id
     client_id = config.microsoft_client_id
     client_secret = config.microsoft_client_secret
-    if not tenant_id or not client_id or not client_secret:
+    client_certificate_path = config.microsoft_client_certificate_path
+    if not tenant_id or not client_id or not (client_secret or client_certificate_path):
         logger.info(
             "O365 import is not configured - skipping this module. "
             "See docs to configure.",
@@ -49,7 +50,12 @@ def start_o365_ingestion(neo4j_session: neo4j.Session, config: Config) -> None:
     }
 
     async def main() -> None:
-        credential = credentials.make_credential(tenant_id, client_id, client_secret)
+        credential = credentials.make_credential(
+            tenant_id,
+            client_id,
+            client_secret,
+            client_certificate_path=client_certificate_path,
+        )
         o365_client = create_graph_service_client(credential)
 
         try:

--- a/docs/root/modules/microsoft/config.md
+++ b/docs/root/modules/microsoft/config.md
@@ -6,7 +6,7 @@ Create an app registration in [App Registrations](https://portal.azure.com/#view
 
 ## Authentication
 
-Create a client secret for the app registration, or upload a certificate to it. Store a secret in an environment variable, or keep the certificate's private key and certificate together in a PEM or PKCS#12 file, and note the Microsoft tenant ID and application client ID.
+Create a client secret for the app registration, or upload a certificate to it. Store a secret in an environment variable, or keep the certificate's private key and certificate together in a PEM or PKCS#12 file, and note the Microsoft tenant ID and application client ID. An encrypted file (a password-protected PFX export, or a PEM with an encrypted private key) is supported when the password is provided through an environment variable; PKCS#12 needs `azure-identity` 1.7.0 or later, which cartography requires.
 
 ## Required Permissions
 
@@ -35,6 +35,7 @@ Provide these options:
 - `--microsoft-client-id`: App registration client ID.
 - `--microsoft-client-secret-env-var`: Name of the environment variable containing the client secret.
 - `--microsoft-client-certificate-path`: Path to a PEM or PKCS#12 file holding the app registration's private key and certificate. Use this instead of `--microsoft-client-secret-env-var` for certificate-based authentication.
+- `--microsoft-client-certificate-password-env-var`: Name of the environment variable containing the password that protects the private key in that file. Omit for an unencrypted file.
 
 These credentials apply to all Microsoft Graph ingestion in the `microsoft` module, including Entra ID and Intune.
 
@@ -59,6 +60,18 @@ cartography \
   --microsoft-tenant-id '<tenant-id>' \
   --microsoft-client-id '<client-id>' \
   --microsoft-client-certificate-path /path/to/app.pem
+```
+
+For an encrypted certificate file, add the password's environment variable:
+
+```bash
+export MICROSOFT_CERT_PASSWORD='<certificate-password>'
+cartography \
+  --selected-modules microsoft \
+  --microsoft-tenant-id '<tenant-id>' \
+  --microsoft-client-id '<client-id>' \
+  --microsoft-client-certificate-path /path/to/app.pfx \
+  --microsoft-client-certificate-password-env-var MICROSOFT_CERT_PASSWORD
 ```
 
 ## References

--- a/docs/root/modules/microsoft/config.md
+++ b/docs/root/modules/microsoft/config.md
@@ -6,7 +6,7 @@ Create an app registration in [App Registrations](https://portal.azure.com/#view
 
 ## Authentication
 
-Create a client secret for the app registration. Store the secret in an environment variable and note the Microsoft tenant ID and application client ID.
+Create a client secret for the app registration, or upload a certificate to it. Store a secret in an environment variable, or keep the certificate's private key and certificate together in a PEM or PKCS#12 file, and note the Microsoft tenant ID and application client ID.
 
 ## Required Permissions
 
@@ -34,6 +34,7 @@ Provide these options:
 - `--microsoft-tenant-id`: Microsoft tenant ID.
 - `--microsoft-client-id`: App registration client ID.
 - `--microsoft-client-secret-env-var`: Name of the environment variable containing the client secret.
+- `--microsoft-client-certificate-path`: Path to a PEM or PKCS#12 file holding the app registration's private key and certificate. Use this instead of `--microsoft-client-secret-env-var` for certificate-based authentication.
 
 These credentials apply to all Microsoft Graph ingestion in the `microsoft` module, including Entra ID and Intune.
 
@@ -48,6 +49,16 @@ cartography \
   --microsoft-tenant-id '<tenant-id>' \
   --microsoft-client-id '<client-id>' \
   --microsoft-client-secret-env-var MICROSOFT_CLIENT_SECRET
+```
+
+Or, with a certificate on the app registration:
+
+```bash
+cartography \
+  --selected-modules microsoft \
+  --microsoft-tenant-id '<tenant-id>' \
+  --microsoft-client-id '<client-id>' \
+  --microsoft-client-certificate-path /path/to/app.pem
 ```
 
 ## References

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -83,7 +83,9 @@ dependencies = [
     "azure-mgmt-storage>=25.0.0",
     "azure-mgmt-sql>=4.0.0",
     "azure-mgmt-authorization>=0.60.0",
-    "azure-identity>=1.5.0",
+    # 1.7.0 is where CertificateCredential accepts PKCS#12 files and a password
+    # (cartography.intel.microsoft.credentials documents both).
+    "azure-identity>=1.7.0",
     "azure-storage-blob>=12.0.0",
     "msgraph-sdk>=1.53.0",
     "kubernetes>=22.6.0",

--- a/tests/integration/cartography/test_cli.py
+++ b/tests/integration/cartography/test_cli.py
@@ -145,6 +145,34 @@ def test_cli_microsoft_credentials_set_config():
     assert config.entra_client_secret == "secret"
 
 
+def test_cli_microsoft_certificate_path_sets_config():
+    # Arrange
+    sync = unittest.mock.MagicMock()
+    cli = cartography.cli.CLI(sync, "test")
+
+    # Act
+    cli.main(
+        [
+            "--neo4j-uri",
+            settings.get("NEO4J_URL"),
+            "--microsoft-tenant-id",
+            "tenant-id",
+            "--microsoft-client-id",
+            "client-id",
+            "--microsoft-client-certificate-path",
+            "/run/secrets/app.pem",
+        ],
+    )
+
+    # Assert
+    sync.run.assert_called_once()
+    config = sync.run.call_args[0][1]
+    assert config.microsoft_tenant_id == "tenant-id"
+    assert config.microsoft_client_id == "client-id"
+    assert config.microsoft_client_certificate_path == "/run/secrets/app.pem"
+    assert config.microsoft_client_secret is None
+
+
 def test_cli_legacy_entra_credentials_set_microsoft_config(caplog):
     # Arrange
     sync = unittest.mock.MagicMock()
@@ -200,8 +228,14 @@ def test_cli_rejects_mixed_microsoft_and_entra_credentials():
     sync.run.assert_not_called()
 
 
-def test_cli_selected_modules_microsoft_help_shows_microsoft_options(capsys):
+def test_cli_selected_modules_microsoft_help_shows_microsoft_options(
+    capsys, monkeypatch
+):
     # Arrange
+    # rich ellipsizes long option names in the default 80-column panel, and the
+    # exact cut point moves whenever a longer option joins it; pin a wide
+    # console so the assertions below can name whole flags.
+    monkeypatch.setenv("COLUMNS", "200")
     sync = unittest.mock.MagicMock()
     cli = cartography.cli.CLI(sync, "test")
     app = cli._build_app(
@@ -215,6 +249,7 @@ def test_cli_selected_modules_microsoft_help_shows_microsoft_options(capsys):
     assert get_args(annotations["microsoft_tenant_id"])[1].hidden is False
     assert get_args(annotations["microsoft_client_id"])[1].hidden is False
     assert get_args(annotations["microsoft_client_secret_env_var"])[1].hidden is False
+    assert get_args(annotations["microsoft_client_certificate_path"])[1].hidden is False
     assert get_args(annotations["entra_tenant_id"])[1].hidden is True
     assert get_args(annotations["entra_client_id"])[1].hidden is True
     assert get_args(annotations["entra_client_secret_env_var"])[1].hidden is True
@@ -229,7 +264,8 @@ def test_cli_selected_modules_microsoft_help_shows_microsoft_options(capsys):
     assert "Microsoft Options" in help_output
     assert "--microsoft-tenant-id" in help_output
     assert "--microsoft-client-id" in help_output
-    assert "--microsoft-client-secret-env-" in help_output
+    assert "--microsoft-client-secret-env-var" in help_output
+    assert "--microsoft-client-certificate-path" in help_output
     assert "--entra-tenant-id" not in help_output
     assert "--entra-client-id" not in help_output
     assert "--entra-client-secret-env-var" not in help_output

--- a/tests/integration/cartography/test_cli.py
+++ b/tests/integration/cartography/test_cli.py
@@ -170,6 +170,37 @@ def test_cli_microsoft_certificate_path_sets_config():
     assert config.microsoft_tenant_id == "tenant-id"
     assert config.microsoft_client_id == "client-id"
     assert config.microsoft_client_certificate_path == "/run/secrets/app.pem"
+    assert config.microsoft_client_certificate_password is None
+    assert config.microsoft_client_secret is None
+
+
+def test_cli_microsoft_certificate_password_is_read_from_the_environment():
+    # Arrange
+    sync = unittest.mock.MagicMock()
+    cli = cartography.cli.CLI(sync, "test")
+
+    # Act
+    with unittest.mock.patch.dict(os.environ, {"MS_CERT_PASSWORD": "pfx-password"}):
+        cli.main(
+            [
+                "--neo4j-uri",
+                settings.get("NEO4J_URL"),
+                "--microsoft-tenant-id",
+                "tenant-id",
+                "--microsoft-client-id",
+                "client-id",
+                "--microsoft-client-certificate-path",
+                "/run/secrets/app.pfx",
+                "--microsoft-client-certificate-password-env-var",
+                "MS_CERT_PASSWORD",
+            ],
+        )
+
+    # Assert: the value, never the variable name, reaches the config
+    sync.run.assert_called_once()
+    config = sync.run.call_args[0][1]
+    assert config.microsoft_client_certificate_path == "/run/secrets/app.pfx"
+    assert config.microsoft_client_certificate_password == "pfx-password"
     assert config.microsoft_client_secret is None
 
 
@@ -250,6 +281,10 @@ def test_cli_selected_modules_microsoft_help_shows_microsoft_options(
     assert get_args(annotations["microsoft_client_id"])[1].hidden is False
     assert get_args(annotations["microsoft_client_secret_env_var"])[1].hidden is False
     assert get_args(annotations["microsoft_client_certificate_path"])[1].hidden is False
+    assert (
+        get_args(annotations["microsoft_client_certificate_password_env_var"])[1].hidden
+        is False
+    )
     assert get_args(annotations["entra_tenant_id"])[1].hidden is True
     assert get_args(annotations["entra_client_id"])[1].hidden is True
     assert get_args(annotations["entra_client_secret_env_var"])[1].hidden is True
@@ -266,6 +301,7 @@ def test_cli_selected_modules_microsoft_help_shows_microsoft_options(
     assert "--microsoft-client-id" in help_output
     assert "--microsoft-client-secret-env-var" in help_output
     assert "--microsoft-client-certificate-path" in help_output
+    assert "--microsoft-client-certificate-password-env-var" in help_output
     assert "--entra-tenant-id" not in help_output
     assert "--entra-client-id" not in help_output
     assert "--entra-client-secret-env-var" not in help_output

--- a/tests/integration/cartography/test_cli.py
+++ b/tests/integration/cartography/test_cli.py
@@ -204,6 +204,29 @@ def test_cli_microsoft_certificate_password_is_read_from_the_environment():
     assert config.microsoft_client_secret is None
 
 
+def test_cli_rejects_certificate_password_without_a_certificate_path():
+    # A password on its own would be dropped and the modules skipped as
+    # unconfigured; refuse it up front instead.
+    sync = unittest.mock.MagicMock()
+    cli = cartography.cli.CLI(sync, "test")
+
+    exit_code = cli.main(
+        [
+            "--neo4j-uri",
+            settings.get("NEO4J_URL"),
+            "--microsoft-tenant-id",
+            "tenant-id",
+            "--microsoft-client-id",
+            "client-id",
+            "--microsoft-client-certificate-password-env-var",
+            "MS_CERT_PASSWORD",
+        ],
+    )
+
+    assert exit_code == 1
+    sync.run.assert_not_called()
+
+
 def test_cli_legacy_entra_credentials_set_microsoft_config(caplog):
     # Arrange
     sync = unittest.mock.MagicMock()

--- a/tests/unit/cartography/intel/microsoft/entra/test_start_entra_ingestion.py
+++ b/tests/unit/cartography/intel/microsoft/entra/test_start_entra_ingestion.py
@@ -1,0 +1,101 @@
+"""start_entra_ingestion with only a certificate configured: every sub-sync must
+receive the certificate path (and password) it needs to build its own
+credential. The config and make_credential tests cover the two ends; this
+covers the forwarding between them, which is where an argument silently
+dropped from one call would otherwise stay green.
+"""
+
+from unittest.mock import AsyncMock
+from unittest.mock import MagicMock
+from unittest.mock import patch
+
+import cartography.intel.microsoft.entra as entra
+from cartography.config import Config
+
+SUB_SYNCS = (
+    "sync_entra_users",
+    "sync_entra_groups",
+    "sync_entra_ous",
+    "sync_entra_applications",
+    "sync_service_principals",
+    "sync_app_role_assignments",
+    "sync_entra_directory_roles",
+)
+ALL_SYNCS = ("sync_tenant", *SUB_SYNCS, "sync_entra_federation")
+
+
+def _certificate_only_config(password: str | None = None) -> Config:
+    return Config(
+        neo4j_uri="bolt://localhost:7687",
+        update_tag=123,
+        microsoft_tenant_id="tenant-id",
+        microsoft_client_id="client-id",
+        microsoft_client_certificate_path="/run/secrets/app.pfx",
+        microsoft_client_certificate_password=password,
+    )
+
+
+def test_start_entra_ingestion_forwards_the_certificate_to_every_sync() -> None:
+    # Arrange: no secret anywhere, only the certificate and its password
+    config = _certificate_only_config(password="pfx-password")
+    session = MagicMock()
+    mocks = {name: AsyncMock() for name in ALL_SYNCS}
+
+    # Act
+    with patch.multiple(entra, **mocks):
+        entra.start_entra_ingestion(session, config)
+
+    # Assert: the tenant load and each resource sync ran once, with
+    # client_secret=None positionally and the certificate as keywords
+    mocks["sync_tenant"].assert_awaited_once_with(
+        session,
+        "tenant-id",
+        "client-id",
+        None,
+        123,
+        client_certificate_path="/run/secrets/app.pfx",
+        client_certificate_password="pfx-password",
+    )
+    common_job_parameters = {"UPDATE_TAG": 123, "TENANT_ID": "tenant-id"}
+    for name in SUB_SYNCS:
+        mocks[name].assert_awaited_once_with(
+            session,
+            "tenant-id",
+            "client-id",
+            None,
+            123,
+            common_job_parameters,
+            client_certificate_path="/run/secrets/app.pfx",
+            client_certificate_password="pfx-password",
+        )
+    mocks["sync_entra_federation"].assert_awaited_once()
+
+
+def test_start_entra_ingestion_runs_with_a_certificate_and_no_secret() -> None:
+    # The module gate used to require a secret; a certificate alone is enough,
+    # and an unencrypted file forwards no password.
+    config = _certificate_only_config()
+    mocks = {name: AsyncMock() for name in ALL_SYNCS}
+
+    with patch.multiple(entra, **mocks):
+        entra.start_entra_ingestion(MagicMock(), config)
+
+    assert all(m.await_count == 1 for m in mocks.values())
+    users_call = mocks["sync_entra_users"].await_args
+    assert users_call is not None
+    assert users_call.kwargs["client_certificate_password"] is None
+
+
+def test_start_entra_ingestion_skips_without_any_credential() -> None:
+    config = Config(
+        neo4j_uri="bolt://localhost:7687",
+        update_tag=123,
+        microsoft_tenant_id="tenant-id",
+        microsoft_client_id="client-id",
+    )
+    mocks = {name: AsyncMock() for name in ALL_SYNCS}
+
+    with patch.multiple(entra, **mocks):
+        entra.start_entra_ingestion(MagicMock(), config)
+
+    assert all(m.await_count == 0 for m in mocks.values())

--- a/tests/unit/cartography/intel/microsoft/test_credentials.py
+++ b/tests/unit/cartography/intel/microsoft/test_credentials.py
@@ -66,7 +66,8 @@ def test_make_credential_forwards_the_certificate_password_only_when_given(
     mock_certificate_credential,
 ) -> None:
     # An encrypted PFX or PEM needs its password; the unencrypted call shape
-    # (no password kwarg at all) is what the test above pins.
+    # (no password kwarg at all) is what the test above pins. An EMPTY password
+    # is still a password (some PFX exports carry one) and is forwarded as such.
     credentials.make_credential(
         "tenant-id",
         "client-id",
@@ -80,6 +81,15 @@ def test_make_credential_forwards_the_certificate_password_only_when_given(
         certificate_path="/run/secrets/app.pfx",
         password="pfx-password",
     )
+
+    mock_certificate_credential.reset_mock()
+    credentials.make_credential(
+        "tenant-id",
+        "client-id",
+        client_certificate_path="/run/secrets/app.pfx",
+        client_certificate_password="",
+    )
+    assert mock_certificate_credential.call_args.kwargs["password"] == ""
 
 
 def test_make_credential_certificate_path_returns_certificate_credential(

--- a/tests/unit/cartography/intel/microsoft/test_credentials.py
+++ b/tests/unit/cartography/intel/microsoft/test_credentials.py
@@ -61,6 +61,27 @@ def test_make_credential_with_certificate_path_builds_certificate_credential(
     assert credential is mock_certificate_credential.return_value
 
 
+@patch("cartography.intel.microsoft.credentials.CertificateCredential")
+def test_make_credential_forwards_the_certificate_password_only_when_given(
+    mock_certificate_credential,
+) -> None:
+    # An encrypted PFX or PEM needs its password; the unencrypted call shape
+    # (no password kwarg at all) is what the test above pins.
+    credentials.make_credential(
+        "tenant-id",
+        "client-id",
+        client_certificate_path="/run/secrets/app.pfx",
+        client_certificate_password="pfx-password",
+    )
+
+    mock_certificate_credential.assert_called_once_with(
+        tenant_id="tenant-id",
+        client_id="client-id",
+        certificate_path="/run/secrets/app.pfx",
+        password="pfx-password",
+    )
+
+
 def test_make_credential_certificate_path_returns_certificate_credential(
     tmp_path,
 ) -> None:

--- a/tests/unit/cartography/intel/microsoft/test_credentials.py
+++ b/tests/unit/cartography/intel/microsoft/test_credentials.py
@@ -1,6 +1,14 @@
+import datetime
 from unittest.mock import patch
 
+import pytest
+from azure.identity import CertificateCredential
 from azure.identity import ClientSecretCredential
+from cryptography import x509
+from cryptography.hazmat.primitives import hashes
+from cryptography.hazmat.primitives import serialization
+from cryptography.hazmat.primitives.asymmetric import rsa
+from cryptography.x509.oid import NameOID
 
 from cartography.intel.microsoft import credentials
 
@@ -31,3 +39,66 @@ def test_make_credential_maps_positional_args(mock_client_secret_credential) -> 
         client_secret="client-secret",
     )
     assert credential is mock_client_secret_credential.return_value
+
+
+@patch("cartography.intel.microsoft.credentials.CertificateCredential")
+def test_make_credential_with_certificate_path_builds_certificate_credential(
+    mock_certificate_credential,
+) -> None:
+    # A certificate replaces the secret: the secret is not required and is never
+    # passed on when a certificate path is given.
+    credential = credentials.make_credential(
+        "tenant-id",
+        "client-id",
+        client_certificate_path="/run/secrets/app.pem",
+    )
+
+    mock_certificate_credential.assert_called_once_with(
+        tenant_id="tenant-id",
+        client_id="client-id",
+        certificate_path="/run/secrets/app.pem",
+    )
+    assert credential is mock_certificate_credential.return_value
+
+
+def test_make_credential_certificate_path_returns_certificate_credential(
+    tmp_path,
+) -> None:
+    # azure-identity parses the certificate as soon as the credential is built,
+    # so this needs a real key + self-signed certificate: the same PEM bundle
+    # shape (PKCS#8 private key, then the certificate) an operator would supply.
+    key = rsa.generate_private_key(public_exponent=65537, key_size=2048)
+    name = x509.Name([x509.NameAttribute(NameOID.COMMON_NAME, "cartography-test")])
+    now = datetime.datetime.now(datetime.timezone.utc)
+    cert = (
+        x509.CertificateBuilder()
+        .subject_name(name)
+        .issuer_name(name)
+        .public_key(key.public_key())
+        .serial_number(x509.random_serial_number())
+        .not_valid_before(now)
+        .not_valid_after(now + datetime.timedelta(days=1))
+        .sign(key, hashes.SHA256())
+    )
+    pem = tmp_path / "app.pem"
+    pem.write_bytes(
+        key.private_bytes(
+            serialization.Encoding.PEM,
+            serialization.PrivateFormat.PKCS8,
+            serialization.NoEncryption(),
+        )
+        + cert.public_bytes(serialization.Encoding.PEM)
+    )
+
+    credential = credentials.make_credential(
+        "tenant-id",
+        "client-id",
+        client_certificate_path=str(pem),
+    )
+
+    assert isinstance(credential, CertificateCredential)
+
+
+def test_make_credential_requires_a_secret_or_a_certificate() -> None:
+    with pytest.raises(ValueError, match="client secret or a client certificate"):
+        credentials.make_credential("tenant-id", "client-id")

--- a/tests/unit/cartography/test_config.py
+++ b/tests/unit/cartography/test_config.py
@@ -108,9 +108,13 @@ def test_config_microsoft_certificate_password_is_stored_beside_the_path() -> No
     assert config.microsoft_client_certificate_password == "pfx-password"
 
 
-def test_config_rejects_certificate_password_without_a_certificate_path() -> None:
-    # Stored on its own the password would leave the Microsoft modules skipped
-    # as unconfigured; refuse it at construction like the CLI does.
+@pytest.mark.parametrize("password", ["pfx-password", ""])
+def test_config_rejects_certificate_password_without_a_certificate_path(
+    password: str,
+) -> None:
+    # Stored on its own the password (even an empty one) would leave the
+    # Microsoft modules skipped as unconfigured; refuse it at construction
+    # like the CLI does.
     with pytest.raises(
         ValueError, match="requires `microsoft_client_certificate_path`"
     ):
@@ -118,7 +122,7 @@ def test_config_rejects_certificate_password_without_a_certificate_path() -> Non
             neo4j_uri="bolt://localhost:7687",
             microsoft_tenant_id="tenant-id",
             microsoft_client_id="client-id",
-            microsoft_client_certificate_password="pfx-password",
+            microsoft_client_certificate_password=password,
         )
 
 

--- a/tests/unit/cartography/test_config.py
+++ b/tests/unit/cartography/test_config.py
@@ -108,6 +108,20 @@ def test_config_microsoft_certificate_password_is_stored_beside_the_path() -> No
     assert config.microsoft_client_certificate_password == "pfx-password"
 
 
+def test_config_rejects_certificate_password_without_a_certificate_path() -> None:
+    # Stored on its own the password would leave the Microsoft modules skipped
+    # as unconfigured; refuse it at construction like the CLI does.
+    with pytest.raises(
+        ValueError, match="requires `microsoft_client_certificate_path`"
+    ):
+        Config(
+            neo4j_uri="bolt://localhost:7687",
+            microsoft_tenant_id="tenant-id",
+            microsoft_client_id="client-id",
+            microsoft_client_certificate_password="pfx-password",
+        )
+
+
 def test_config_rejects_certificate_password_mixed_with_entra_credentials() -> None:
     with pytest.raises(ValueError, match="Cannot mix Microsoft credential"):
         Config(

--- a/tests/unit/cartography/test_config.py
+++ b/tests/unit/cartography/test_config.py
@@ -109,9 +109,7 @@ def test_config_microsoft_certificate_password_is_stored_beside_the_path() -> No
 
 
 @pytest.mark.parametrize("password", ["pfx-password", ""])
-def test_config_rejects_certificate_password_without_a_certificate_path(
-    password: str,
-) -> None:
+def test_config_rejects_certificate_password_without_a_certificate_path(password):
     # Stored on its own the password (even an empty one) would leave the
     # Microsoft modules skipped as unconfigured; refuse it at construction
     # like the CLI does.

--- a/tests/unit/cartography/test_config.py
+++ b/tests/unit/cartography/test_config.py
@@ -23,6 +23,9 @@ def test_aws_organization_account_ids_preserves_config_positional_compatibility(
     assert parameters.index("microsoft_client_secret") > parameters.index(
         "microsoft_client_id",
     )
+    assert parameters.index("microsoft_client_certificate_path") > parameters.index(
+        "microsoft_client_secret",
+    )
 
 
 def test_bbot_source_preserves_config_positional_compatibility() -> None:
@@ -73,6 +76,30 @@ def test_config_microsoft_credentials_are_canonical(caplog) -> None:
     assert config.entra_client_id == "client-id"
     assert config.entra_client_secret == "client-secret"
     assert "DEPRECATED" not in caplog.text
+
+
+def test_config_microsoft_certificate_path_is_stored_without_a_secret() -> None:
+    # Arrange and act
+    config = Config(
+        neo4j_uri="bolt://localhost:7687",
+        microsoft_tenant_id="tenant-id",
+        microsoft_client_id="client-id",
+        microsoft_client_certificate_path="/run/secrets/app.pem",
+    )
+
+    # Assert
+    assert config.microsoft_client_certificate_path == "/run/secrets/app.pem"
+    assert config.microsoft_client_secret is None
+
+
+def test_config_rejects_certificate_path_mixed_with_entra_credentials() -> None:
+    # Act and assert
+    with pytest.raises(ValueError, match="Cannot mix Microsoft credential"):
+        Config(
+            neo4j_uri="bolt://localhost:7687",
+            microsoft_client_certificate_path="/run/secrets/app.pem",
+            entra_tenant_id="tenant-id",
+        )
 
 
 def test_config_legacy_entra_credentials_populate_microsoft_aliases(caplog) -> None:

--- a/tests/unit/cartography/test_config.py
+++ b/tests/unit/cartography/test_config.py
@@ -26,6 +26,9 @@ def test_aws_organization_account_ids_preserves_config_positional_compatibility(
     assert parameters.index("microsoft_client_certificate_path") > parameters.index(
         "microsoft_client_secret",
     )
+    assert parameters.index("microsoft_client_certificate_password") > parameters.index(
+        "microsoft_client_certificate_path"
+    )
 
 
 def test_bbot_source_preserves_config_positional_compatibility() -> None:
@@ -89,7 +92,29 @@ def test_config_microsoft_certificate_path_is_stored_without_a_secret() -> None:
 
     # Assert
     assert config.microsoft_client_certificate_path == "/run/secrets/app.pem"
+    assert config.microsoft_client_certificate_password is None
     assert config.microsoft_client_secret is None
+
+
+def test_config_microsoft_certificate_password_is_stored_beside_the_path() -> None:
+    config = Config(
+        neo4j_uri="bolt://localhost:7687",
+        microsoft_tenant_id="tenant-id",
+        microsoft_client_id="client-id",
+        microsoft_client_certificate_path="/run/secrets/app.pfx",
+        microsoft_client_certificate_password="pfx-password",
+    )
+
+    assert config.microsoft_client_certificate_password == "pfx-password"
+
+
+def test_config_rejects_certificate_password_mixed_with_entra_credentials() -> None:
+    with pytest.raises(ValueError, match="Cannot mix Microsoft credential"):
+        Config(
+            neo4j_uri="bolt://localhost:7687",
+            microsoft_client_certificate_password="pfx-password",
+            entra_tenant_id="tenant-id",
+        )
 
 
 def test_config_rejects_certificate_path_mixed_with_entra_credentials() -> None:

--- a/uv.lock
+++ b/uv.lock
@@ -884,7 +884,7 @@ doc = [
 [package.metadata]
 requires-dist = [
     { name = "aioboto3", specifier = ">=15.0.0" },
-    { name = "azure-identity", specifier = ">=1.5.0" },
+    { name = "azure-identity", specifier = ">=1.7.0" },
     { name = "azure-keyvault-certificates", specifier = ">=4.0.0" },
     { name = "azure-keyvault-keys", specifier = ">=4.0.0" },
     { name = "azure-keyvault-secrets", specifier = ">=4.0.0" },


### PR DESCRIPTION
### Type of change
- [ ] Bug fix (non-breaking change that fixes an issue)
- [x] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Refactoring (no functional changes)
- [ ] Documentation update
- [ ] Other (please describe):


### Summary
The Microsoft module (Entra, Intune, O365) can only authenticate its app registration with a client secret: `--microsoft-client-secret-env-var` is the sole credential input and every sync builds a `ClientSecretCredential`. Entra app registrations also accept certificate credentials, and some tenants run certificate-only registrations (no secret exists to put in an env var), so today those tenants cannot sync Entra at all.

This adds a certificate path as an alternative to the secret:

- `--microsoft-client-certificate-path` / `Config.microsoft_client_certificate_path`: path to a PEM or PKCS#12 file holding the registration's private key and certificate. Used instead of `--microsoft-client-secret-env-var`. The existing guard against mixing the deprecated `--entra-*` flags with `--microsoft-*` covers the new option too.
- `credentials.make_credential` builds an azure-identity `CertificateCredential` when a path is given, a `ClientSecretCredential` otherwise, and raises if it has neither. Each Microsoft sync function gains a keyword-only `client_certificate_path` and forwards it, so existing positional call sites are unchanged.
- The module gate accepts a secret OR a certificate path.
- Docs: the option and a run example in `docs/root/modules/microsoft/config.md`.

No node or relationship changes; the graph produced is identical.

### Related issues or links
None found for certificate auth on the Microsoft module.

### How was this tested?
- `make test_lint` clean on the changed files; `mypy` clean.
- New/updated tests (run with `uv run pytest`):
  - `tests/unit/cartography/intel/microsoft/test_credentials.py`: secret path unchanged; certificate path returns a `CertificateCredential` (mocked, and with a real self-signed key + certificate generated with `cryptography`, in the key-then-certificate PEM shape an operator supplies, because azure-identity parses the file eagerly); neither given raises.
  - `tests/unit/cartography/test_config.py`: the new field, and the mixing check with the deprecated `--entra-*` flags.
  - `tests/integration/cartography/test_cli.py`: option wiring and the Microsoft help panel. The help test now pins `COLUMNS=200`: rich ellipsizes option names in the default 80-column panel, and the cut point moved when this longer flag joined it.
- Full unit suite: 5338 passed. Two failures in `tests/unit/cartography/intel/common/test_object_store.py` are Windows path-separator issues on my machine (`nested\findings.json` vs `nested/findings.json`) in a module this change does not touch.
- Real tenant (certificate-only app registration, Entra + Intune + O365 permissions): the sync below ran on 2026-09-09 against a tenant with 77 users, 103 groups, 757 service principals and 145 role definitions and completed without errors. Honest caveat on how it was produced: it is from our production runner, which is pinned to the 0.138.1 image, so it exercises the same construction this PR makes, `CertificateCredential(tenant_id=..., client_id=..., certificate_path=...)`, through a small `sitecustomize` shim that swaps `ClientSecretCredential` for it, rather than the branch itself; I could not get the private key onto a machine that could run this branch. The shim is what this PR retires. Sanitized log:

<details><summary>Entra sync log (sanitized)</summary>

```
2026-09-09T08:12:19 Auth method : certificate
2026-09-09T08:12:19 [*] Resolving credentials for m365/certificate...
2026-09-09T08:12:24 [+] Using Entra application with certificate (client <client-id>, tenant <tenant-id>)
2026-09-09T08:12:27 [+] Entra certificate shim on PYTHONPATH (cartography has no certificate flag; ClientSecretCredential -> CertificateCredential for this process)
2026-09-09T08:12:40 [*] Running Cartography (m365) into the ephemeral graph...
2026-09-09T08:12:42 INFO:cartography.sync:Starting sync with update tag '1788941562'
2026-09-09T08:12:42 INFO:cartography.sync:Starting sync stage 'microsoft'
2026-09-09T08:12:48 INFO:cartography.client.core.tx:Loaded 1 AzureTenant nodes
2026-09-09T08:12:51 INFO:cartography.client.core.tx:Loaded 77 EntraUser nodes
2026-09-09T08:13:12 INFO:cartography.client.core.tx:Loaded 100 EntraGroup nodes
2026-09-09T08:13:14 INFO:cartography.client.core.tx:Loaded 3 EntraGroup nodes
2026-09-09T08:13:16 INFO:cartography.client.core.tx:Loaded 10 EntraApplication nodes
2026-09-09T08:13:16 INFO:cartography.client.core.tx:Loaded 10 EntraApplication nodes
2026-09-09T08:13:16 INFO:cartography.client.core.tx:Loaded 5 EntraApplication nodes
2026-09-09T08:13:16 INFO:cartography.intel.microsoft.entra.applications:Completed syncing 25 applications
2026-09-09T08:13:18 INFO:cartography.client.core.tx:Loaded 50 EntraServicePrincipal nodes
2026-09-09T08:13:18 INFO:cartography.client.core.tx:Loaded 50 EntraServicePrincipal nodes
2026-09-09T08:13:19 INFO:cartography.client.core.tx:Loaded 50 EntraServicePrincipal nodes
2026-09-09T08:13:19 INFO:cartography.client.core.tx:Loaded 50 EntraServicePrincipal nodes
2026-09-09T08:13:20 INFO:cartography.client.core.tx:Loaded 50 EntraServicePrincipal nodes
2026-09-09T08:13:20 INFO:cartography.client.core.tx:Loaded 50 EntraServicePrincipal nodes
2026-09-09T08:13:21 INFO:cartography.client.core.tx:Loaded 50 EntraServicePrincipal nodes
2026-09-09T08:13:21 INFO:cartography.client.core.tx:Loaded 50 EntraServicePrincipal nodes
2026-09-09T08:13:22 INFO:cartography.client.core.tx:Loaded 50 EntraServicePrincipal nodes
2026-09-09T08:13:22 INFO:cartography.client.core.tx:Loaded 50 EntraServicePrincipal nodes
2026-09-09T08:13:23 INFO:cartography.client.core.tx:Loaded 50 EntraServicePrincipal nodes
2026-09-09T08:13:23 INFO:cartography.client.core.tx:Loaded 50 EntraServicePrincipal nodes
2026-09-09T08:13:23 INFO:cartography.client.core.tx:Loaded 50 EntraServicePrincipal nodes
2026-09-09T08:13:24 INFO:cartography.client.core.tx:Loaded 50 EntraServicePrincipal nodes
2026-09-09T08:13:24 INFO:cartography.client.core.tx:Loaded 50 EntraServicePrincipal nodes
2026-09-09T08:13:24 INFO:cartography.client.core.tx:Loaded 7 EntraServicePrincipal nodes
2026-09-09T08:13:29 INFO:cartography.client.core.tx:Loaded 100 EntraAppRoleAssignment nodes
2026-09-09T08:13:30 INFO:cartography.intel.microsoft.entra.applications:Completed syncing 100 app role assignments
2026-09-09T08:13:31 INFO:cartography.client.core.tx:Loaded 145 EntraRoleDefinition nodes
2026-09-09T08:13:31 INFO:cartography.intel.microsoft.entra.directory_roles:Loaded 145 Entra role definitions
2026-09-09T08:13:32 INFO:cartography.client.core.tx:Loaded 13 EntraRoleAssignment nodes
2026-09-09T08:13:32 INFO:cartography.intel.microsoft.entra.directory_roles:Loaded 13 Entra role assignments
2026-09-09T08:13:36 INFO:cartography.client.core.tx:Loaded 55 IntuneManagedDevice nodes
2026-09-09T08:14:18 INFO:cartography.client.core.tx:Loaded 100 IntuneDetectedApp nodes
2026-09-09T08:14:19 INFO:cartography.client.core.tx:Loaded 100 IntuneDetectedApp nodes
2026-09-09T08:14:19 INFO:cartography.client.core.tx:Loaded 100 IntuneDetectedApp nodes
2026-09-09T08:14:19 INFO:cartography.client.core.tx:Loaded 100 IntuneDetectedApp nodes
2026-09-09T08:14:19 INFO:cartography.client.core.tx:Loaded 100 IntuneDetectedApp nodes
2026-09-09T08:14:19 INFO:cartography.client.core.tx:Loaded 100 IntuneDetectedApp nodes
2026-09-09T08:14:19 INFO:cartography.client.core.tx:Loaded 100 IntuneDetectedApp nodes
2026-09-09T08:14:19 INFO:cartography.client.core.tx:Loaded 100 IntuneDetectedApp nodes
2026-09-09T08:14:19 INFO:cartography.client.core.tx:Loaded 100 IntuneDetectedApp nodes
2026-09-09T08:14:19 INFO:cartography.client.core.tx:Loaded 100 IntuneDetectedApp nodes
2026-09-09T08:14:19 INFO:cartography.client.core.tx:Loaded 100 IntuneDetectedApp nodes
2026-09-09T08:14:19 INFO:cartography.client.core.tx:Loaded 100 IntuneDetectedApp nodes
2026-09-09T08:14:19 INFO:cartography.client.core.tx:Loaded 100 IntuneDetectedApp nodes
2026-09-09T08:14:19 INFO:cartography.client.core.tx:Loaded 100 IntuneDetectedApp nodes
2026-09-09T08:14:19 INFO:cartography.client.core.tx:Loaded 100 IntuneDetectedApp nodes
2026-09-09T08:14:20 INFO:cartography.client.core.tx:Loaded 100 IntuneDetectedApp nodes
2026-09-09T08:14:20 INFO:cartography.client.core.tx:Loaded 95 IntuneDetectedApp nodes
2026-09-09T08:14:24 INFO:cartography.client.core.tx:Loaded 500 (IntuneDetectedApp)-[HAS_APP]->(IntuneManagedDevice) relationships
2026-09-09T08:14:27 INFO:cartography.client.core.tx:Loaded 500 (IntuneDetectedApp)-[HAS_APP]->(IntuneManagedDevice) relationships
2026-09-09T08:14:30 INFO:cartography.client.core.tx:Loaded 500 (IntuneDetectedApp)-[HAS_APP]->(IntuneManagedDevice) relationships
2026-09-09T08:14:33 INFO:cartography.client.core.tx:Loaded 500 (IntuneDetectedApp)-[HAS_APP]->(IntuneManagedDevice) relationships
2026-09-09T08:14:35 INFO:cartography.client.core.tx:Loaded 500 (IntuneDetectedApp)-[HAS_APP]->(IntuneManagedDevice) relationships
2026-09-09T08:14:37 INFO:cartography.client.core.tx:Loaded 500 (IntuneDetectedApp)-[HAS_APP]->(IntuneManagedDevice) relationships
2026-09-09T08:14:40 INFO:cartography.client.core.tx:Loaded 500 (IntuneDetectedApp)-[HAS_APP]->(IntuneManagedDevice) relationships
2026-09-09T08:14:42 INFO:cartography.client.core.tx:Loaded 500 (IntuneDetectedApp)-[HAS_APP]->(IntuneManagedDevice) relationships
2026-09-09T08:14:44 INFO:cartography.client.core.tx:Loaded 500 (IntuneDetectedApp)-[HAS_APP]->(IntuneManagedDevice) relationships
2026-09-09T08:14:46 INFO:cartography.client.core.tx:Loaded 500 (IntuneDetectedApp)-[HAS_APP]->(IntuneManagedDevice) relationships
2026-09-09T08:14:48 INFO:cartography.client.core.tx:Loaded 500 (IntuneDetectedApp)-[HAS_APP]->(IntuneManagedDevice) relationships
2026-09-09T08:14:50 INFO:cartography.client.core.tx:Loaded 500 (IntuneDetectedApp)-[HAS_APP]->(IntuneManagedDevice) relationships
2026-09-09T08:14:53 INFO:cartography.client.core.tx:Loaded 500 (IntuneDetectedApp)-[HAS_APP]->(IntuneManagedDevice) relationships
2026-09-09T08:14:55 INFO:cartography.client.core.tx:Loaded 500 (IntuneDetectedApp)-[HAS_APP]->(IntuneManagedDevice) relationships
2026-09-09T08:14:57 INFO:cartography.client.core.tx:Loaded 500 (IntuneDetectedApp)-[HAS_APP]->(IntuneManagedDevice) relationships
2026-09-09T08:14:59 INFO:cartography.client.core.tx:Loaded 500 (IntuneDetectedApp)-[HAS_APP]->(IntuneManagedDevice) relationships
2026-09-09T08:15:01 INFO:cartography.client.core.tx:Loaded 500 (IntuneDetectedApp)-[HAS_APP]->(IntuneManagedDevice) relationships
2026-09-09T08:15:03 INFO:cartography.client.core.tx:Loaded 500 (IntuneDetectedApp)-[HAS_APP]->(IntuneManagedDevice) relationships
2026-09-09T08:15:05 INFO:cartography.client.core.tx:Loaded 269 (IntuneDetectedApp)-[HAS_APP]->(IntuneManagedDevice) relationships
2026-09-09T08:15:05 INFO:cartography.sync:Finishing sync stage 'microsoft'
2026-09-09T08:15:05 INFO:cartography.sync:Finishing sync with update tag '1788941562'
2026-09-09T08:15:10 [+] completeness gate passed for m365 (EntraUser, EntraRoleDefinition all non-zero)
2026-09-09T08:15:10 [+] Cartography edge extraction complete for <uuid>
```

</details>

### Checklist

#### General
- [x] I have read the [contributing guidelines](https://github.com/cartography-cncf/cartography/blob/master/CONTRIBUTING.md).
- [x] The linter passes locally (`make test_lint`).
- [x] I have added/updated tests that prove my fix is effective or my feature works.
- [x] Every commit includes a DCO `Signed-off-by` trailer.

#### Proof of functionality
- [ ] Screenshot showing the graph before and after changes.
- [x] New or updated unit/integration tests.

#### If you are adding or modifying an intel connector
- [x] Tested the connector against a real cloud, SaaS, or provider environment.
- [x] Included sanitized Cartography sync logs demonstrating successful synchronization of the new/modified connector behavior (see above, with the caveat on how it was produced).
- [x] Removed credentials, personal data, account identifiers, and other sensitive values from the evidence.

### Notes for reviewers
- The certificate is read by azure-identity itself (`CertificateCredential(certificate_path=...)`), so PEM and PKCS#12 both work and no new dependency is added.
- `make_credential` keeps `client_secret` positional for compatibility and takes the certificate path keyword-only; a future cleanup could make both keyword-only.
