### PR TITLE
fix(ci): cancel superseded pull request runs

### DIFF
--- a/.github/workflows/sphinx.yml
+++ b/.github/workflows/sphinx.yml
@@ -9,6 +9,10 @@ on:
     branches:
       - 'master'
 
+concurrency:
+  group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.run_id }}
+  cancel-in-progress: true
+
 # Declare default permissions as read only.
 permissions: read-all
 

--- a/.github/workflows/test_suite.yml
+++ b/.github/workflows/test_suite.yml
@@ -7,6 +7,10 @@ on:
     branches:
       - master
 
+concurrency:
+  group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.run_id }}
+  cancel-in-progress: true
+
 # Explicitly grant the `secrets.GITHUB_TOKEN` no permissions.
 permissions: {}
 


### PR DESCRIPTION
### Type of change

- [x] Other: CI workflow configuration

### Summary

Cancel superseded pull-request runs for the test and documentation workflows. Both workflows use a concurrency group scoped to the workflow and pull request number, so a newer commit replaces obsolete work from the same PR.

Push runs use their unique run ID. This preserves every default-branch test and documentation deployment instead of cancelling one push when another arrives.

This reduces wasted runner capacity and stale queue entries. It does not change GitHub-hosted runner availability or concurrency limits.

https://docs.github.com/en/actions/how-tos/write-workflows/choose-when-workflows-run/control-workflow-concurrency
