### PR TITLE
fix(aws): skip Bedrock knowledge bases in Melbourne

### DIFF
--- a/cartography/intel/aws/bedrock/__init__.py
+++ b/cartography/intel/aws/bedrock/__init__.py
@@ -123,10 +123,13 @@ def sync(
     )
 
     # Sync knowledge bases (before agents, since agents can reference KBs)
+    # Melbourne's ListKnowledgeBases endpoint returns InternalServerException,
+    # while ListAgents succeeds. Keep this exclusion specific to knowledge bases.
+    # https://docs.aws.amazon.com/bedrock/latest/userguide/knowledge-base-supported.html
     knowledge_bases.sync(
         neo4j_session,
         boto3_session,
-        bedrock_agent_regions,
+        [region for region in bedrock_agent_regions if region != "ap-southeast-4"],
         current_aws_account_id,
         update_tag,
         common_job_parameters,

--- a/tests/unit/cartography/intel/aws/test_bedrock.py
+++ b/tests/unit/cartography/intel/aws/test_bedrock.py
@@ -1,15 +1,18 @@
 from unittest.mock import MagicMock
 
+import pytest
+
 from cartography.intel.aws import bedrock
 
 
-def test_sync_skips_us_west_1_for_bedrock_agent_apis(mocker):
+@pytest.mark.parametrize("agent_regions", [[], ["ap-southeast-4", "us-west-2"]])
+def test_sync_filters_regions_per_bedrock_resource(mocker, agent_regions):
     # Arrange
     boto3_session = MagicMock()
     boto3_session.get_partition_for_region.return_value = "aws"
     boto3_session.get_available_regions.side_effect = lambda service, **_: {
-        "bedrock": ["us-west-1", "us-west-2"],
-        "bedrock-agent": [],
+        "bedrock": ["us-west-1", "ap-southeast-4", "us-west-2"],
+        "bedrock-agent": agent_regions,
     }[service]
     sync_mocks = {
         module: mocker.patch.object(module, "sync")
@@ -32,7 +35,7 @@ def test_sync_skips_us_west_1_for_bedrock_agent_apis(mocker):
     bedrock.sync(
         neo4j_session=neo4j_session,
         boto3_session=boto3_session,
-        regions=["us-west-1", "us-west-2"],
+        regions=["us-west-1", "ap-southeast-4", "us-west-2"],
         current_aws_account_id="123456789012",
         update_tag=123,
         common_job_parameters=common_job_parameters,
@@ -48,17 +51,24 @@ def test_sync_skips_us_west_1_for_bedrock_agent_apis(mocker):
         sync_mocks[module].assert_called_once_with(
             neo4j_session,
             boto3_session,
-            ["us-west-1", "us-west-2"],
+            ["us-west-1", "ap-southeast-4", "us-west-2"],
             "123456789012",
             123,
             common_job_parameters,
         )
-    for module in (bedrock.knowledge_bases, bedrock.agents):
-        sync_mocks[module].assert_called_once_with(
-            neo4j_session,
-            boto3_session,
-            ["us-west-2"],
-            "123456789012",
-            123,
-            common_job_parameters,
-        )
+    sync_mocks[bedrock.knowledge_bases].assert_called_once_with(
+        neo4j_session,
+        boto3_session,
+        ["us-west-2"],
+        "123456789012",
+        123,
+        common_job_parameters,
+    )
+    sync_mocks[bedrock.agents].assert_called_once_with(
+        neo4j_session,
+        boto3_session,
+        ["ap-southeast-4", "us-west-2"],
+        "123456789012",
+        123,
+        common_job_parameters,
+    )


### PR DESCRIPTION
### Type of change
- [x] Bug fix (non-breaking change that fixes an issue)

### Summary
Skip `ap-southeast-4` (Melbourne) for Bedrock knowledge-base ingestion only. `ListKnowledgeBases` returns `InternalServerException` there, while `ListAgents` succeeds. The repeated failure can stop the account sync even when there are no knowledge bases to ingest in that region.

Keep Melbourne enabled for agents and other Bedrock resources. Keep the existing `us-west-1` exclusion unchanged. This does not catch or suppress HTTP 500 errors in other regions or change cleanup code.

AWS's feature-specific documentation does not list Melbourne for the documented Knowledge Bases configurations. The exclusion is a targeted workaround supported by observed API behavior, not a general assumption that HTTP 500 means a region is unsupported. Revisit it when the regional API becomes usable.

### Related issues or links
- Follow-up to #3238.
- [Knowledge Bases model and region support](https://docs.aws.amazon.com/bedrock/latest/userguide/knowledge-base-supported.html)
- [Bedrock endpoints](https://docs.aws.amazon.com/general/latest/gr/bedrock.html)
- [ListKnowledgeBases API and errors](https://docs.aws.amazon.com/bedrock/latest/APIReference/API_agent_ListKnowledgeBases.html)

### How was this tested?
- Read-only API checks: Melbourne `ListKnowledgeBases` returned HTTP 500; Melbourne `ListAgents` returned HTTP 200. Both operations returned HTTP 200 in `us-east-1`.
- Ran the changed `bedrock.sync()` against real AWS APIs for Melbourne and Hyderabad (`ap-south-2`), writing only to a new isolated local database. The sync completed, loaded 43 foundation-model nodes and 43 relationships, queried agents in both regions, and queried knowledge bases only in Hyderabad. These regions contained no agents or knowledge bases, so populated graph behavior is covered by the existing integration tests rather than this live run.

Sanitized live sync excerpt (account identifiers replaced; unrelated lines omitted):
```text
INFO:cartography.intel.aws.bedrock:Syncing AWS Bedrock resources for account <redacted> across 2 requested regions
INFO:cartography.client.core.tx:Loaded 22 AWSBedrockFoundationModel nodes
INFO:cartography.client.core.tx:Loaded 21 AWSBedrockFoundationModel nodes
INFO:cartography.intel.aws.bedrock.knowledge_bases:Syncing Bedrock knowledge bases for account <redacted> across 1 regions
INFO:cartography.intel.aws.bedrock.knowledge_bases:Found 0 knowledge base summaries in region ap-south-2
INFO:cartography.intel.aws.bedrock.agents:Found 0 agent summaries in region ap-southeast-4
INFO:cartography.intel.aws.bedrock.agents:Found 0 agent summaries in region ap-south-2
INFO:cartography.intel.aws.bedrock:Completed AWS Bedrock sync for account <redacted>
```

### Checklist
#### General
- [x] I have read the contributing guidelines.
- [x] The linter passes locally (`make test_lint`).
- [x] I have added/updated tests that prove my fix is effective or my feature works.
- [x] Every commit includes a DCO `Signed-off-by` trailer.

#### Proof of functionality
- [x] New or updated unit/integration tests.

#### If you are adding or modifying an intel connector
- [x] Tested the connector against a real cloud, SaaS, or provider environment.
- [x] Included sanitized Cartography sync logs demonstrating successful synchronization of the new/modified connector behavior.
- [x] Removed credentials, personal data, account identifiers, and other sensitive values from the evidence.
