### PR TITLE
feat(aws): ingest WAF web ACLs and rules

### DIFF
--- a/cartography/intel/aws/__init__.py
+++ b/cartography/intel/aws/__init__.py
@@ -162,6 +162,11 @@ def _sync_one_account(
         "s3": ["kms"],
         "rds": ["kms"],
         "efs": ["kms"],
+        # WAF creates PROTECTS edges to resources already present in the graph.
+        "waf": ["ec2:load_balancer_v2", "cognito"],
+        # These modules create PROTECTS edges from an existing WAF web ACL.
+        "apigateway": ["waf"],
+        "cloudfront": ["waf"],
         # `route53` creates DNS_POINTS_TO edges by matching already-existing target nodes,
         # so selecting it without these produces zero such edges, and cleanup_route53 then
         # deletes the ones a previous run had created. AWSESDomain is deliberately absent:

--- a/cartography/intel/aws/cognito.py
+++ b/cartography/intel/aws/cognito.py
@@ -194,15 +194,15 @@ def sync(
                 update_tag,
             )
 
-            user_pools = get_user_pools(boto3_session, region)
-            transformed_user_pools = transform_user_pools(user_pools, region)
+        user_pools = get_user_pools(boto3_session, region)
+        transformed_user_pools = transform_user_pools(user_pools, region)
 
-            load_user_pools(
-                neo4j_session,
-                transformed_user_pools,
-                region,
-                current_aws_account_id,
-                update_tag,
-            )
+        load_user_pools(
+            neo4j_session,
+            transformed_user_pools,
+            region,
+            current_aws_account_id,
+            update_tag,
+        )
 
     cleanup(neo4j_session, common_job_parameters)

--- a/cartography/intel/aws/resourcegroupstaggingapi.py
+++ b/cartography/intel/aws/resourcegroupstaggingapi.py
@@ -87,7 +87,11 @@ def get_resource_type_from_arn(arn: str) -> str:
         return service
 
     resource = parts[5]
-    if service == "elasticloadbalancing" and resource.startswith("loadbalancer/"):
+    if service == "wafv2":
+        # WAFv2 ARNs include their scope before the resource type:
+        # regional/webacl/... or global/webacl/....
+        resource_type = resource.split("/", 2)[1]
+    elif service == "elasticloadbalancing" and resource.startswith("loadbalancer/"):
         segments = resource.split("/")
         if len(segments) > 2 and segments[1] in {"app", "net"}:
             resource_type = f"{segments[0]}/{segments[1]}"
@@ -328,6 +332,7 @@ _RESOURCE_CLEANUP_PATHS: Dict[str, str] = {
     "AWSInternetGateway": (
         "(:AWSInternetGateway)<-[:RESOURCE]-(:AWSAccount{id: $AWS_ID})"
     ),
+    "AWSWAFWebACL": "(:AWSWAFWebACL)<-[:RESOURCE]-(:AWSAccount{id: $AWS_ID})",
 }
 
 

--- a/cartography/intel/aws/resources.py
+++ b/cartography/intel/aws/resources.py
@@ -47,6 +47,7 @@ from . import ses
 from . import sns
 from . import sqs
 from . import ssm
+from . import waf
 from .ec2.auto_scaling_groups import sync_ec2_auto_scaling_groups
 from .ec2.elastic_ip_addresses import sync_elastic_ip_addresses
 from .ec2.images import sync_ec2_images
@@ -135,6 +136,11 @@ RESOURCE_FUNCTIONS: OrderedDict[str, Callable[..., None]] = OrderedDict(
         # nodes exist when CAN_EXEC edges are evaluated.
         "cloudformation": cloudformation.sync,
         "permission_relationships": permission_relationships.sync,
+        # Cognito pools and load balancers must exist before WAF creates PROTECTS
+        # relationships. WAF must exist before API Gateway and CloudFront create
+        # their PROTECTS relationships from their own association fields.
+        "cognito": cognito.sync,
+        "waf": waf.sync,
         "resourcegroupstaggingapi": resourcegroupstaggingapi.sync,
         "apigateway": apigateway.sync,
         "apigatewayv2": apigatewayv2.sync,
@@ -161,7 +167,6 @@ RESOURCE_FUNCTIONS: OrderedDict[str, Callable[..., None]] = OrderedDict(
         "eks": eks.sync,
         "guardduty": guardduty.sync,
         "codebuild": codebuild.sync,
-        "cognito": cognito.sync,
         "eventbridge": eventbridge.sync,
         "glue": glue.sync,
         # These resources feed final AWS analysis jobs and have no remaining

--- a/cartography/intel/aws/waf.py
+++ b/cartography/intel/aws/waf.py
@@ -1,0 +1,403 @@
+import json
+import logging
+from typing import Any
+
+import boto3
+import neo4j
+
+from cartography.client.core.tx import load
+from cartography.graph.job import GraphJob
+from cartography.intel.aws.util.botocore_config import create_boto3_client
+from cartography.models.aws.waf.web_acl import WAFRuleSchema
+from cartography.models.aws.waf.web_acl import WAFWebACLSchema
+from cartography.stats import get_stats_client
+from cartography.util import aws_handle_regions
+from cartography.util import merge_module_sync_metadata
+from cartography.util import timeit
+
+logger = logging.getLogger(__name__)
+stat_handler = get_stats_client(__name__)
+
+CLOUDFRONT_REGION = "us-east-1"
+# API Gateway and CloudFront expose their WAF associations in their own APIs.
+# Other ListResourcesForWebACL target types do not yet have Cartography models.
+REGIONAL_RESOURCE_TYPES = (
+    "APPLICATION_LOAD_BALANCER",
+    "COGNITO_USER_POOL",
+)
+
+
+def _list_with_marker(
+    client: Any,
+    operation: str,
+    result_key: str,
+    **kwargs: Any,
+) -> list[dict[str, Any]]:
+    """Collect a WAFv2 list operation, whose APIs don't expose boto3 paginators."""
+    result: list[dict[str, Any]] = []
+    while True:
+        response = getattr(client, operation)(**kwargs)
+        result.extend(response.get(result_key, []))
+        marker = response.get("NextMarker")
+        if not marker:
+            return result
+        kwargs["NextMarker"] = marker
+
+
+@timeit
+@aws_handle_regions
+def get_web_acls(
+    boto3_session: boto3.session.Session,
+    region: str,
+    scope: str,
+    scan_status: dict[str, bool] | None = None,
+) -> list[dict[str, Any]]:
+    """Retrieve complete web ACL objects for one AWS WAF scope."""
+    client = create_boto3_client(boto3_session, "wafv2", region_name=region)
+    summaries = _list_with_marker(client, "list_web_acls", "WebACLs", Scope=scope)
+    web_acls: list[dict[str, Any]] = []
+    for summary in summaries:
+        response = client.get_web_acl(ARN=summary["ARN"])
+        web_acls.append(response["WebACL"])
+    if scan_status is not None:
+        scan_status["complete"] = True
+    return web_acls
+
+
+@timeit
+@aws_handle_regions
+def get_logging_configurations(
+    boto3_session: boto3.session.Session,
+    region: str,
+    scope: str,
+    scan_status: dict[str, bool] | None = None,
+) -> list[dict[str, Any]]:
+    """Retrieve customer-managed logging configurations for one AWS WAF scope."""
+    client = create_boto3_client(boto3_session, "wafv2", region_name=region)
+    configurations = _list_with_marker(
+        client,
+        "list_logging_configurations",
+        "LoggingConfigurations",
+        Scope=scope,
+        LogScope="CUSTOMER",
+    )
+    if scan_status is not None:
+        scan_status["complete"] = True
+    return configurations
+
+
+@timeit
+@aws_handle_regions
+def get_protected_resources(
+    boto3_session: boto3.session.Session,
+    region: str,
+    web_acl_arn: str,
+    scan_status: dict[str, bool] | None = None,
+) -> list[dict[str, str]]:
+    """Retrieve supported regional resources associated with a web ACL."""
+    client = create_boto3_client(boto3_session, "wafv2", region_name=region)
+    resources: list[dict[str, str]] = []
+    for resource_type in REGIONAL_RESOURCE_TYPES:
+        response = client.list_resources_for_web_acl(
+            WebACLArn=web_acl_arn,
+            ResourceType=resource_type,
+        )
+        resources.extend(
+            {"ResourceType": resource_type, "ResourceArn": resource_arn}
+            for resource_arn in response.get("ResourceArns", [])
+        )
+    if scan_status is not None:
+        scan_status["complete"] = True
+    return resources
+
+
+def _json(value: Any) -> str | None:
+    return json.dumps(value, sort_keys=True, default=str) if value else None
+
+
+def _action_name(action: dict[str, Any] | None) -> str | None:
+    return next(iter(action)).upper() if action else None
+
+
+def _statement_metadata(statement: dict[str, Any]) -> dict[str, list[Any]]:
+    metadata: dict[str, list[Any]] = {
+        "StatementTypes": [],
+        "ReferencedRuleGroupArns": [],
+        "ReferencedIPSetArns": [],
+        "ReferencedRegexPatternSetArns": [],
+        "ManagedRuleGroups": [],
+        "RateLimits": [],
+    }
+
+    def walk(value: Any) -> None:
+        if isinstance(value, dict):
+            for key, child in value.items():
+                if key.endswith("Statement") and key not in metadata["StatementTypes"]:
+                    metadata["StatementTypes"].append(key)
+                if key == "RuleGroupReferenceStatement" and child.get("ARN"):
+                    metadata["ReferencedRuleGroupArns"].append(child["ARN"])
+                elif key == "IPSetReferenceStatement" and child.get("ARN"):
+                    metadata["ReferencedIPSetArns"].append(child["ARN"])
+                elif key == "RegexPatternSetReferenceStatement" and child.get("ARN"):
+                    metadata["ReferencedRegexPatternSetArns"].append(child["ARN"])
+                elif key == "ManagedRuleGroupStatement":
+                    version = child.get("Version")
+                    reference = f'{child["VendorName"]}/{child["Name"]}'
+                    metadata["ManagedRuleGroups"].append(
+                        f"{reference}/{version}" if version else reference,
+                    )
+                elif key == "RateBasedStatement" and child.get("Limit") is not None:
+                    metadata["RateLimits"].append(child["Limit"])
+                walk(child)
+        elif isinstance(value, list):
+            for child in value:
+                walk(child)
+
+    walk(statement)
+    return metadata
+
+
+def _transform_rule(
+    rule: dict[str, Any],
+    web_acl_arn: str,
+    phase: str,
+) -> dict[str, Any]:
+    statement = rule.get("Statement") or rule.get("FirewallManagerStatement") or {}
+    visibility = rule.get("VisibilityConfig", {})
+    return {
+        "RuleId": f'{web_acl_arn}:{phase}:{rule["Priority"]}:{rule["Name"]}',
+        "WebACLArn": web_acl_arn,
+        "Name": rule["Name"],
+        "Priority": rule["Priority"],
+        "Phase": phase,
+        "Action": _action_name(rule.get("Action")),
+        "OverrideAction": _action_name(rule.get("OverrideAction")),
+        "Statement": _json(statement),
+        "SampledRequestsEnabled": visibility.get("SampledRequestsEnabled"),
+        "CloudWatchMetricsEnabled": visibility.get("CloudWatchMetricsEnabled"),
+        "MetricName": visibility.get("MetricName"),
+        **_statement_metadata(statement),
+    }
+
+
+def transform(
+    web_acls: list[dict[str, Any]],
+    logging_configurations: list[dict[str, Any]],
+    protected_resources: dict[str, list[dict[str, str]]],
+    region: str,
+    scope: str,
+) -> tuple[list[dict[str, Any]], list[dict[str, Any]]]:
+    """Transform AWS WAF responses into web ACL and rule records."""
+    logging_by_arn = {
+        config["ResourceArn"]: config for config in logging_configurations
+    }
+    transformed_acls: list[dict[str, Any]] = []
+    transformed_rules: list[dict[str, Any]] = []
+
+    for web_acl in web_acls:
+        arn = web_acl["ARN"]
+        visibility = web_acl.get("VisibilityConfig", {})
+        logging_config = logging_by_arn.get(arn, {})
+        resources = protected_resources.get(arn, [])
+        transformed_acls.append(
+            {
+                "ARN": arn,
+                "Id": web_acl["Id"],
+                "Name": web_acl["Name"],
+                "Description": web_acl.get("Description"),
+                "Scope": scope,
+                "Region": region,
+                "Capacity": web_acl.get("Capacity"),
+                "DefaultAction": _action_name(web_acl.get("DefaultAction")),
+                "ManagedByFirewallManager": web_acl.get("ManagedByFirewallManager"),
+                "RetrofittedByFirewallManager": web_acl.get(
+                    "RetrofittedByFirewallManager",
+                ),
+                "LabelNamespace": web_acl.get("LabelNamespace"),
+                "TokenDomains": web_acl.get("TokenDomains"),
+                "SampledRequestsEnabled": visibility.get("SampledRequestsEnabled"),
+                "CloudWatchMetricsEnabled": visibility.get(
+                    "CloudWatchMetricsEnabled",
+                ),
+                "MetricName": visibility.get("MetricName"),
+                "LoggingEnabled": bool(logging_config),
+                "LogDestinationConfigs": logging_config.get(
+                    "LogDestinationConfigs",
+                ),
+                "RedactedFieldTypes": [
+                    next(iter(field))
+                    for field in logging_config.get("RedactedFields", [])
+                    if field
+                ],
+                "LoggingFilter": _json(logging_config.get("LoggingFilter")),
+                "AssociationConfig": _json(web_acl.get("AssociationConfig")),
+                "OnSourceDDoSProtectionConfig": _json(
+                    web_acl.get("OnSourceDDoSProtectionConfig"),
+                ),
+                "ProtectedLoadBalancerArns": [
+                    resource["ResourceArn"]
+                    for resource in resources
+                    if resource["ResourceType"] == "APPLICATION_LOAD_BALANCER"
+                ],
+                "ProtectedCognitoUserPoolIds": [
+                    resource["ResourceArn"].rsplit("/", 1)[-1]
+                    for resource in resources
+                    if resource["ResourceType"] == "COGNITO_USER_POOL"
+                ],
+            },
+        )
+
+        for phase, rules in (
+            ("regular", web_acl.get("Rules", [])),
+            ("pre_process", web_acl.get("PreProcessFirewallManagerRuleGroups", [])),
+            ("post_process", web_acl.get("PostProcessFirewallManagerRuleGroups", [])),
+        ):
+            transformed_rules.extend(
+                _transform_rule(rule, arn, phase) for rule in rules
+            )
+
+    return transformed_acls, transformed_rules
+
+
+def load_web_acls(
+    neo4j_session: neo4j.Session,
+    web_acls: list[dict[str, Any]],
+    rules: list[dict[str, Any]],
+    current_aws_account_id: str,
+    update_tag: int,
+) -> None:
+    load(
+        neo4j_session,
+        WAFWebACLSchema(),
+        web_acls,
+        lastupdated=update_tag,
+        AWS_ID=current_aws_account_id,
+    )
+    load(
+        neo4j_session,
+        WAFRuleSchema(),
+        rules,
+        lastupdated=update_tag,
+        AWS_ID=current_aws_account_id,
+    )
+
+
+def cleanup(
+    neo4j_session: neo4j.Session,
+    common_job_parameters: dict[str, Any],
+) -> None:
+    GraphJob.from_node_schema(WAFRuleSchema(), common_job_parameters).run(
+        neo4j_session,
+    )
+    GraphJob.from_node_schema(WAFWebACLSchema(), common_job_parameters).run(
+        neo4j_session,
+    )
+
+
+def _sync_scope(
+    neo4j_session: neo4j.Session,
+    boto3_session: boto3.session.Session,
+    region: str,
+    scope: str,
+    current_aws_account_id: str,
+    update_tag: int,
+) -> bool:
+    scan_status: dict[str, bool] = {}
+    web_acls = get_web_acls(boto3_session, region, scope, scan_status)
+    if not scan_status.get("complete"):
+        return False
+    if not web_acls:
+        return True
+
+    scan_status = {}
+    logging_configurations = get_logging_configurations(
+        boto3_session,
+        region,
+        scope,
+        scan_status,
+    )
+    if not scan_status.get("complete"):
+        return False
+
+    protected_resources: dict[str, list[dict[str, str]]] = {}
+    if scope == "REGIONAL":
+        for web_acl in web_acls:
+            scan_status = {}
+            resources = get_protected_resources(
+                boto3_session,
+                region,
+                web_acl["ARN"],
+                scan_status,
+            )
+            if not scan_status.get("complete"):
+                return False
+            protected_resources[web_acl["ARN"]] = resources
+    transformed_acls, transformed_rules = transform(
+        web_acls,
+        logging_configurations,
+        protected_resources,
+        region,
+        scope,
+    )
+    load_web_acls(
+        neo4j_session,
+        transformed_acls,
+        transformed_rules,
+        current_aws_account_id,
+        update_tag,
+    )
+    return True
+
+
+@timeit
+def sync(
+    neo4j_session: neo4j.Session,
+    boto3_session: boto3.session.Session,
+    regions: list[str],
+    current_aws_account_id: str,
+    update_tag: int,
+    common_job_parameters: dict[str, Any],
+) -> None:
+    """Sync regional and CloudFront-scoped AWS WAFv2 web ACLs."""
+    scan_complete = True
+    for region in regions:
+        scan_complete = (
+            _sync_scope(
+                neo4j_session,
+                boto3_session,
+                region,
+                "REGIONAL",
+                current_aws_account_id,
+                update_tag,
+            )
+            and scan_complete
+        )
+
+    scan_complete = (
+        _sync_scope(
+            neo4j_session,
+            boto3_session,
+            CLOUDFRONT_REGION,
+            "CLOUDFRONT",
+            current_aws_account_id,
+            update_tag,
+        )
+        and scan_complete
+    )
+    if not scan_complete:
+        logger.warning(
+            "Skipping AWS WAF cleanup and sync metadata because the scan was incomplete",
+        )
+        return
+
+    cleanup(neo4j_session, common_job_parameters)
+
+    for synced_type in ("AWSWAFWebACL", "AWSWAFRule"):
+        merge_module_sync_metadata(
+            neo4j_session,
+            group_type="AWSAccount",
+            group_id=current_aws_account_id,
+            synced_type=synced_type,
+            update_tag=update_tag,
+            stat_handler=stat_handler,
+        )

--- a/cartography/models/aws/apigateway/apigatewaystage.py
+++ b/cartography/models/aws/apigateway/apigatewaystage.py
@@ -87,6 +87,26 @@ class APIGatewayStageToAWSAccountRel(CartographyRelSchema):
 
 
 @dataclass(frozen=True)
+class WAFWebACLToAPIGatewayStageRelProperties(CartographyRelProperties):
+    lastupdated: PropertyRef = PropertyRef("lastupdated", set_in_kwargs=True)
+
+
+@dataclass(frozen=True)
+class WAFWebACLToAPIGatewayStageRel(CartographyRelSchema):
+    """Indicates that an AWS WAF web ACL protects the API Gateway stage."""
+
+    target_node_label: str = "AWSWAFWebACL"
+    target_node_matcher: TargetNodeMatcher = make_target_node_matcher(
+        {"arn": PropertyRef("webAclArn")},
+    )
+    direction: LinkDirection = LinkDirection.INWARD
+    rel_label: str = "PROTECTS"
+    properties: WAFWebACLToAPIGatewayStageRelProperties = (
+        WAFWebACLToAPIGatewayStageRelProperties()
+    )
+
+
+@dataclass(frozen=True)
 class APIGatewayStageSchema(CartographyNodeSchema):
     """Representation of an AWS [API Gateway Stage](https://docs.aws.amazon.com/apigateway/latest/developerguide/set-up-stages.html)."""
 
@@ -98,5 +118,8 @@ class APIGatewayStageSchema(CartographyNodeSchema):
         APIGatewayStageToAWSAccountRel()
     )
     other_relationships: OtherRelationships = OtherRelationships(
-        [APIGatewayStageToRestAPIRel()],
+        [
+            APIGatewayStageToRestAPIRel(),
+            WAFWebACLToAPIGatewayStageRel(),
+        ],
     )

--- a/cartography/models/aws/cloudfront/distribution.py
+++ b/cartography/models/aws/cloudfront/distribution.py
@@ -225,6 +225,26 @@ class CloudFrontDistributionToLambdaRel(CartographyRelSchema):
 
 
 @dataclass(frozen=True)
+class WAFWebACLToCloudFrontDistributionRelProperties(CartographyRelProperties):
+    lastupdated: PropertyRef = PropertyRef("lastupdated", set_in_kwargs=True)
+
+
+@dataclass(frozen=True)
+class WAFWebACLToCloudFrontDistributionRel(CartographyRelSchema):
+    """Indicates that an AWS WAFv2 web ACL protects the distribution."""
+
+    target_node_label: str = "AWSWAFWebACL"
+    target_node_matcher: TargetNodeMatcher = make_target_node_matcher(
+        {"arn": PropertyRef("WebACLId")},
+    )
+    direction: LinkDirection = LinkDirection.INWARD
+    rel_label: str = "PROTECTS"
+    properties: WAFWebACLToCloudFrontDistributionRelProperties = (
+        WAFWebACLToCloudFrontDistributionRelProperties()
+    )
+
+
+@dataclass(frozen=True)
 class CloudFrontDistributionSchema(CartographyNodeSchema):
     """Representation of an AWS [CloudFront Distribution](https://docs.aws.amazon.com/cloudfront/latest/APIReference/API_DistributionSummary.html).
 
@@ -247,5 +267,6 @@ class CloudFrontDistributionSchema(CartographyNodeSchema):
             CloudFrontDistributionToS3BucketRel(),
             CloudFrontDistributionToACMCertificateRel(),
             CloudFrontDistributionToLambdaRel(),
+            WAFWebACLToCloudFrontDistributionRel(),
         ],
     )

--- a/cartography/models/aws/waf/__init__.py
+++ b/cartography/models/aws/waf/__init__.py
@@ -1,0 +1,1 @@
+"""AWS WAF data models."""

--- a/cartography/models/aws/waf/web_acl.py
+++ b/cartography/models/aws/waf/web_acl.py
@@ -1,0 +1,300 @@
+from dataclasses import dataclass
+
+from cartography.models.core.common import PropertyRef
+from cartography.models.core.nodes import CartographyNodeProperties
+from cartography.models.core.nodes import CartographyNodeSchema
+from cartography.models.core.nodes import ExtraNodeLabels
+from cartography.models.core.relationships import CartographyRelProperties
+from cartography.models.core.relationships import CartographyRelSchema
+from cartography.models.core.relationships import LinkDirection
+from cartography.models.core.relationships import make_target_node_matcher
+from cartography.models.core.relationships import OtherRelationships
+from cartography.models.core.relationships import TargetNodeMatcher
+from cartography.models.ontology.labels import NETWORK_ACCESS_CONTROL
+
+
+@dataclass(frozen=True)
+class WAFWebACLNodeProperties(CartographyNodeProperties):
+    id: PropertyRef = PropertyRef(
+        "ARN",
+        description="The ARN of the AWS WAF web ACL.",
+    )
+    arn: PropertyRef = PropertyRef(
+        "ARN",
+        extra_index=True,
+        description="The ARN of the AWS WAF web ACL.",
+    )
+    web_acl_id: PropertyRef = PropertyRef(
+        "Id",
+        description="The AWS-generated identifier of the web ACL.",
+    )
+    name: PropertyRef = PropertyRef(
+        "Name",
+        extra_index=True,
+        description="The name of the web ACL.",
+    )
+    description: PropertyRef = PropertyRef(
+        "Description",
+        description="A description of the web ACL.",
+    )
+    scope: PropertyRef = PropertyRef(
+        "Scope",
+        description="Whether the web ACL protects regional or CloudFront resources.",
+    )
+    region: PropertyRef = PropertyRef(
+        "Region",
+        description="The AWS API region used to retrieve the web ACL.",
+    )
+    capacity: PropertyRef = PropertyRef(
+        "Capacity",
+        description="The web ACL capacity units currently used by its rules.",
+    )
+    default_action: PropertyRef = PropertyRef(
+        "DefaultAction",
+        description="The action applied when no rule matches.",
+    )
+    managed_by_firewall_manager: PropertyRef = PropertyRef(
+        "ManagedByFirewallManager",
+        description="Whether AWS Firewall Manager manages the web ACL.",
+    )
+    retrofitted_by_firewall_manager: PropertyRef = PropertyRef(
+        "RetrofittedByFirewallManager",
+        description="Whether AWS Firewall Manager retrofitted the web ACL.",
+    )
+    label_namespace: PropertyRef = PropertyRef(
+        "LabelNamespace",
+        description="The namespace AWS WAF uses for labels emitted by this web ACL.",
+    )
+    token_domains: PropertyRef = PropertyRef(
+        "TokenDomains",
+        description="Domains accepted for AWS WAF tokens.",
+    )
+    sampled_requests_enabled: PropertyRef = PropertyRef(
+        "SampledRequestsEnabled",
+        description="Whether AWS WAF stores sampled requests for the web ACL.",
+    )
+    cloudwatch_metrics_enabled: PropertyRef = PropertyRef(
+        "CloudWatchMetricsEnabled",
+        description="Whether CloudWatch metrics are enabled for the web ACL.",
+    )
+    metric_name: PropertyRef = PropertyRef(
+        "MetricName",
+        description="The CloudWatch metric name for the web ACL.",
+    )
+    logging_enabled: PropertyRef = PropertyRef(
+        "LoggingEnabled",
+        description="Whether request logging is configured for the web ACL.",
+    )
+    log_destination_arns: PropertyRef = PropertyRef(
+        "LogDestinationConfigs",
+        description="ARNs of the destinations that receive AWS WAF logs.",
+    )
+    redacted_field_types: PropertyRef = PropertyRef(
+        "RedactedFieldTypes",
+        description="Request field types redacted from AWS WAF logs.",
+    )
+    logging_filter: PropertyRef = PropertyRef(
+        "LoggingFilter",
+        description="The AWS WAF logging filter encoded as JSON.",
+    )
+    association_config: PropertyRef = PropertyRef(
+        "AssociationConfig",
+        description="Per-resource request body inspection settings encoded as JSON.",
+    )
+    on_source_ddos_protection_config: PropertyRef = PropertyRef(
+        "OnSourceDDoSProtectionConfig",
+        description="The web ACL's on-source DDoS protection settings encoded as JSON.",
+    )
+    lastupdated: PropertyRef = PropertyRef("lastupdated", set_in_kwargs=True)
+
+
+@dataclass(frozen=True)
+class WAFWebACLToAWSAccountRelProperties(CartographyRelProperties):
+    lastupdated: PropertyRef = PropertyRef("lastupdated", set_in_kwargs=True)
+
+
+@dataclass(frozen=True)
+class WAFWebACLToAWSAccountRel(CartographyRelSchema):
+    """Indicates that an AWS account contains the web ACL."""
+
+    target_node_label: str = "AWSAccount"
+    target_node_matcher: TargetNodeMatcher = make_target_node_matcher(
+        {"id": PropertyRef("AWS_ID", set_in_kwargs=True)},
+    )
+    direction: LinkDirection = LinkDirection.INWARD
+    rel_label: str = "RESOURCE"
+    properties: WAFWebACLToAWSAccountRelProperties = (
+        WAFWebACLToAWSAccountRelProperties()
+    )
+
+
+@dataclass(frozen=True)
+class WAFWebACLToLoadBalancerRelProperties(CartographyRelProperties):
+    lastupdated: PropertyRef = PropertyRef("lastupdated", set_in_kwargs=True)
+
+
+@dataclass(frozen=True)
+class WAFWebACLToLoadBalancerRel(CartographyRelSchema):
+    """Indicates that the web ACL protects an Application Load Balancer."""
+
+    target_node_label: str = "AWSLoadBalancerV2"
+    target_node_matcher: TargetNodeMatcher = make_target_node_matcher(
+        {"arn": PropertyRef("ProtectedLoadBalancerArns", one_to_many=True)},
+    )
+    direction: LinkDirection = LinkDirection.OUTWARD
+    rel_label: str = "PROTECTS"
+    properties: WAFWebACLToLoadBalancerRelProperties = (
+        WAFWebACLToLoadBalancerRelProperties()
+    )
+
+
+@dataclass(frozen=True)
+class WAFWebACLToCognitoUserPoolRelProperties(CartographyRelProperties):
+    lastupdated: PropertyRef = PropertyRef("lastupdated", set_in_kwargs=True)
+
+
+@dataclass(frozen=True)
+class WAFWebACLToCognitoUserPoolRel(CartographyRelSchema):
+    """Indicates that the web ACL protects an Amazon Cognito user pool."""
+
+    target_node_label: str = "AWSCognitoUserPool"
+    target_node_matcher: TargetNodeMatcher = make_target_node_matcher(
+        {"id": PropertyRef("ProtectedCognitoUserPoolIds", one_to_many=True)},
+    )
+    direction: LinkDirection = LinkDirection.OUTWARD
+    rel_label: str = "PROTECTS"
+    properties: WAFWebACLToCognitoUserPoolRelProperties = (
+        WAFWebACLToCognitoUserPoolRelProperties()
+    )
+
+
+@dataclass(frozen=True)
+class WAFWebACLSchema(CartographyNodeSchema):
+    """An AWS WAF v2 [web ACL](https://docs.aws.amazon.com/waf/latest/APIReference/API_WebACL.html) that filters HTTP(S) requests for protected resources.
+
+    This node has the extra label `NetworkAccessControl` to enable cross-platform
+    queries for network access controls.
+    """
+
+    label: str = "AWSWAFWebACL"
+    properties: WAFWebACLNodeProperties = WAFWebACLNodeProperties()
+    extra_node_labels: ExtraNodeLabels = ExtraNodeLabels([NETWORK_ACCESS_CONTROL])
+    sub_resource_relationship: WAFWebACLToAWSAccountRel = WAFWebACLToAWSAccountRel()
+    other_relationships: OtherRelationships = OtherRelationships(
+        [
+            WAFWebACLToLoadBalancerRel(),
+            WAFWebACLToCognitoUserPoolRel(),
+        ],
+    )
+
+
+@dataclass(frozen=True)
+class WAFRuleNodeProperties(CartographyNodeProperties):
+    id: PropertyRef = PropertyRef(
+        "RuleId",
+        description="Stable identifier composed from the owning web ACL and rule.",
+    )
+    name: PropertyRef = PropertyRef("Name", description="The name of the rule.")
+    priority: PropertyRef = PropertyRef(
+        "Priority",
+        description="The rule evaluation priority within its phase.",
+    )
+    phase: PropertyRef = PropertyRef(
+        "Phase",
+        description="The rule phase: regular, Firewall Manager pre-process, or post-process.",
+    )
+    action: PropertyRef = PropertyRef(
+        "Action",
+        description="The action applied when the rule matches.",
+    )
+    override_action: PropertyRef = PropertyRef(
+        "OverrideAction",
+        description="The action override applied to a referenced rule group.",
+    )
+    statement_types: PropertyRef = PropertyRef(
+        "StatementTypes",
+        description="Statement types used by the rule, including nested statements.",
+    )
+    statement: PropertyRef = PropertyRef(
+        "Statement",
+        description="The complete AWS WAF statement encoded as JSON.",
+    )
+    referenced_rule_group_arns: PropertyRef = PropertyRef(
+        "ReferencedRuleGroupArns",
+        description="ARNs of customer-managed rule groups referenced by the rule.",
+    )
+    referenced_ip_set_arns: PropertyRef = PropertyRef(
+        "ReferencedIPSetArns",
+        description="ARNs of IP sets referenced by the rule.",
+    )
+    referenced_regex_pattern_set_arns: PropertyRef = PropertyRef(
+        "ReferencedRegexPatternSetArns",
+        description="ARNs of regex pattern sets referenced by the rule.",
+    )
+    managed_rule_groups: PropertyRef = PropertyRef(
+        "ManagedRuleGroups",
+        description="Referenced managed rule groups in vendor/name/version form.",
+    )
+    rate_limits: PropertyRef = PropertyRef(
+        "RateLimits",
+        description="Request limits from rate-based statements used by the rule.",
+    )
+    sampled_requests_enabled: PropertyRef = PropertyRef(
+        "SampledRequestsEnabled",
+        description="Whether AWS WAF stores sampled requests for the rule.",
+    )
+    cloudwatch_metrics_enabled: PropertyRef = PropertyRef(
+        "CloudWatchMetricsEnabled",
+        description="Whether CloudWatch metrics are enabled for the rule.",
+    )
+    metric_name: PropertyRef = PropertyRef(
+        "MetricName",
+        description="The CloudWatch metric name for the rule.",
+    )
+    lastupdated: PropertyRef = PropertyRef("lastupdated", set_in_kwargs=True)
+
+
+@dataclass(frozen=True)
+class WAFRuleToAWSAccountRelProperties(CartographyRelProperties):
+    lastupdated: PropertyRef = PropertyRef("lastupdated", set_in_kwargs=True)
+
+
+@dataclass(frozen=True)
+class WAFRuleToAWSAccountRel(CartographyRelSchema):
+    """Indicates that an AWS account contains the WAF rule."""
+
+    target_node_label: str = "AWSAccount"
+    target_node_matcher: TargetNodeMatcher = make_target_node_matcher(
+        {"id": PropertyRef("AWS_ID", set_in_kwargs=True)},
+    )
+    direction: LinkDirection = LinkDirection.INWARD
+    rel_label: str = "RESOURCE"
+    properties: WAFRuleToAWSAccountRelProperties = WAFRuleToAWSAccountRelProperties()
+
+
+@dataclass(frozen=True)
+class WAFRuleToWebACLRelProperties(CartographyRelProperties):
+    lastupdated: PropertyRef = PropertyRef("lastupdated", set_in_kwargs=True)
+
+
+@dataclass(frozen=True)
+class WAFRuleToWebACLRel(CartographyRelSchema):
+    """Indicates that a web ACL contains the rule."""
+
+    target_node_label: str = "AWSWAFWebACL"
+    target_node_matcher: TargetNodeMatcher = make_target_node_matcher(
+        {"arn": PropertyRef("WebACLArn")},
+    )
+    direction: LinkDirection = LinkDirection.INWARD
+    rel_label: str = "HAS_RULE"
+    properties: WAFRuleToWebACLRelProperties = WAFRuleToWebACLRelProperties()
+
+
+@dataclass(frozen=True)
+class WAFRuleSchema(CartographyNodeSchema):
+    """A rule evaluated by an AWS WAF web ACL or AWS Firewall Manager phase."""
+
+    label: str = "AWSWAFRule"
+    properties: WAFRuleNodeProperties = WAFRuleNodeProperties()
+    sub_resource_relationship: WAFRuleToAWSAccountRel = WAFRuleToAWSAccountRel()
+    other_relationships: OtherRelationships = OtherRelationships([WAFRuleToWebACLRel()])

--- a/cartography/models/aws_tagging.py
+++ b/cartography/models/aws_tagging.py
@@ -120,4 +120,5 @@ AWS_TAGGABLE_RESOURCES = (
         "id",
     ),
     AWSTaggableResource("sqs", "AWSSQSQueue", "id"),
+    AWSTaggableResource("wafv2:webacl", "AWSWAFWebACL", "arn"),
 )

--- a/cartography/models/ontology/constraints.py
+++ b/cartography/models/ontology/constraints.py
@@ -115,6 +115,8 @@ ONTOLOGY_REL_CONSTRAINTS: tuple[RelConstraint, ...] = (
     # analysis output.
     RelConstraint(src="LoadBalancer", dst="ComputePod", label="EXPOSE"),
     RelConstraint(src="LoadBalancer", dst="Container", label="EXPOSE"),
+    # A network access control protects the load balancer it is attached to.
+    RelConstraint(src="NetworkAccessControl", dst="LoadBalancer", label="PROTECTS"),
     # NOTE: no constraint for the entrypoint types that are not load balancers
     # (RailwayServiceDomain, RailwayCustomDomain, RailwayTCPProxy,
     # ModalSandboxTunnel). They carry no ontology label, so a constraint on them

--- a/cartography/models/ontology/mapping/data/firewalls.py
+++ b/cartography/models/ontology/mapping/data/firewalls.py
@@ -25,6 +25,15 @@ aws_mapping = OntologyMapping(
                 # rule nodes instead.
             ],
         ),
+        OntologyNodeMapping(
+            node_label="AWSWAFWebACL",
+            fields=[
+                OntologyFieldMapping(
+                    ontology_field="name", node_field="name", required=True
+                ),
+                # direction: Not applicable (web ACLs inspect inbound HTTP requests)
+            ],
+        ),
     ],
 )
 

--- a/docs/root/modules/aws/config.md
+++ b/docs/root/modules/aws/config.md
@@ -91,6 +91,10 @@ hierarchy APIs such as `ListRoots`, `ListAccountsForParent`, and
   `ecr:DescribePullThroughCacheRules`.
 - AWS Glue connection ingestion requires `glue:GetConnections`, which
   `SecurityAudit` does not include.
+- AWS WAFv2 web ACL, rule, logging, and supported resource-association ingestion
+  uses the `wafv2:GetWebACL`, `wafv2:ListWebACLs`,
+  `wafv2:ListLoggingConfigurations`, and `wafv2:ListResourcesForWebACL`
+  permissions included in `SecurityAudit`.
 
 ## Configure Cartography
 

--- a/tests/data/aws/waf.py
+++ b/tests/data/aws/waf.py
@@ -1,0 +1,116 @@
+TEST_ACCOUNT_ID = "000000000000"
+REGIONAL_WEB_ACL_ARN = (
+    f"arn:aws:wafv2:us-west-2:{TEST_ACCOUNT_ID}:regional/webacl/regional-acl/acl-1"
+)
+CLOUDFRONT_WEB_ACL_ARN = (
+    f"arn:aws:wafv2:us-east-1:{TEST_ACCOUNT_ID}:global/webacl/cloudfront-acl/acl-2"
+)
+LOAD_BALANCER_ARN = (
+    f"arn:aws:elasticloadbalancing:us-west-2:{TEST_ACCOUNT_ID}:"
+    "loadbalancer/app/example/abc123"
+)
+COGNITO_USER_POOL_ARN = (
+    f"arn:aws:cognito-idp:us-west-2:{TEST_ACCOUNT_ID}:userpool/us-west-2_Example"
+)
+
+REGIONAL_WEB_ACLS = [
+    {
+        "Name": "regional-acl",
+        "Id": "acl-1",
+        "ARN": REGIONAL_WEB_ACL_ARN,
+        "Description": "Protects regional applications",
+        "DefaultAction": {"Allow": {}},
+        "Capacity": 125,
+        "ManagedByFirewallManager": False,
+        "RetrofittedByFirewallManager": False,
+        "LabelNamespace": f"awswaf:{TEST_ACCOUNT_ID}:webacl:regional-acl:",
+        "VisibilityConfig": {
+            "SampledRequestsEnabled": True,
+            "CloudWatchMetricsEnabled": True,
+            "MetricName": "regional-acl",
+        },
+        "Rules": [
+            {
+                "Name": "rate-limit-login",
+                "Priority": 1,
+                "Statement": {
+                    "RateBasedStatement": {
+                        "Limit": 100,
+                        "AggregateKeyType": "IP",
+                        "ScopeDownStatement": {
+                            "IPSetReferenceStatement": {
+                                "ARN": f"arn:aws:wafv2:us-west-2:{TEST_ACCOUNT_ID}:regional/ipset/office/ipset-1",
+                            },
+                        },
+                    },
+                },
+                "Action": {"Block": {}},
+                "VisibilityConfig": {
+                    "SampledRequestsEnabled": True,
+                    "CloudWatchMetricsEnabled": True,
+                    "MetricName": "rate-limit-login",
+                },
+            },
+        ],
+    },
+]
+
+CLOUDFRONT_WEB_ACLS = [
+    {
+        "Name": "cloudfront-acl",
+        "Id": "acl-2",
+        "ARN": CLOUDFRONT_WEB_ACL_ARN,
+        "DefaultAction": {"Block": {}},
+        "Capacity": 700,
+        "ManagedByFirewallManager": True,
+        "VisibilityConfig": {
+            "SampledRequestsEnabled": False,
+            "CloudWatchMetricsEnabled": True,
+            "MetricName": "cloudfront-acl",
+        },
+        "Rules": [
+            {
+                "Name": "aws-common-rules",
+                "Priority": 10,
+                "Statement": {
+                    "ManagedRuleGroupStatement": {
+                        "VendorName": "AWS",
+                        "Name": "AWSManagedRulesCommonRuleSet",
+                        "Version": "Version_1.0",
+                    },
+                },
+                "OverrideAction": {"None": {}},
+                "VisibilityConfig": {
+                    "SampledRequestsEnabled": False,
+                    "CloudWatchMetricsEnabled": True,
+                    "MetricName": "aws-common-rules",
+                },
+            },
+        ],
+    },
+]
+
+LOGGING_CONFIGURATIONS = [
+    {
+        "ResourceArn": REGIONAL_WEB_ACL_ARN,
+        "LogDestinationConfigs": [
+            f"arn:aws:logs:us-west-2:{TEST_ACCOUNT_ID}:log-group:aws-waf-logs-main",
+        ],
+        "RedactedFields": [{"SingleHeader": {"Name": "authorization"}}],
+        "LoggingFilter": {
+            "DefaultBehavior": "KEEP",
+            "Filters": [],
+        },
+    },
+]
+
+PROTECTED_RESOURCES = [
+    {
+        "ResourceType": "APPLICATION_LOAD_BALANCER",
+        "ResourceArn": LOAD_BALANCER_ARN,
+    },
+    {
+        "ResourceType": "COGNITO_USER_POOL",
+        "ResourceArn": COGNITO_USER_POOL_ARN,
+    },
+]

--- a/tests/integration/cartography/intel/aws/test_apigateway.py
+++ b/tests/integration/cartography/intel/aws/test_apigateway.py
@@ -108,6 +108,12 @@ def test_load_apigateway_stages(neo4j_session):
 
 
 def test_load_apigateway_stages_relationships(neo4j_session):
+    web_acl_arn = tests.data.aws.apigateway.GET_STAGES[0]["webAclArn"]
+    neo4j_session.run(
+        "MERGE (:AWSWAFWebACL {arn: $arn})",
+        arn=web_acl_arn,
+    )
+
     # Load Test REST API
     data_rest_api = tests.data.aws.apigateway.GET_REST_APIS
     cartography.intel.aws.apigateway.load_apigateway_rest_apis(
@@ -148,6 +154,18 @@ def test_load_apigateway_stages_relationships(neo4j_session):
     actual = {(r["n1.id"], r["n2.id"]) for r in result}
 
     assert actual == expected
+    assert check_rels(
+        neo4j_session,
+        "AWSWAFWebACL",
+        "arn",
+        "AWSAPIGatewayStage",
+        "id",
+        "PROTECTS",
+        rel_direction_right=True,
+    ) == {
+        (web_acl_arn, "arn:aws:apigateway:::test-001/Cartography-testing-infra"),
+        (web_acl_arn, "arn:aws:apigateway:::test-002/Cartography-testing-unit"),
+    }
 
 
 def test_load_apigateway_certificates(neo4j_session):

--- a/tests/integration/cartography/intel/aws/test_cloudfront.py
+++ b/tests/integration/cartography/intel/aws/test_cloudfront.py
@@ -128,6 +128,11 @@ def test_sync_cloudfront_with_lambda(mock_get_distributions, neo4j_session):
     _cleanup_cloudfront(neo4j_session)
     boto3_session = MagicMock()
     create_test_account(neo4j_session, TEST_ACCOUNT_ID, TEST_UPDATE_TAG)
+    web_acl_arn = test_data.CLOUDFRONT_DISTRIBUTIONS_WITH_LAMBDA[0]["WebACLId"]
+    neo4j_session.run(
+        "MERGE (:AWSWAFWebACL {arn: $arn})",
+        arn=web_acl_arn,
+    )
 
     # Pre-create Lambda function nodes to test relationships
     neo4j_session.run(
@@ -175,6 +180,20 @@ def test_sync_cloudfront_with_lambda(mock_get_distributions, neo4j_session):
         f"arn:aws:cloudfront::{TEST_ACCOUNT_ID}:distribution/E7F8G9H0I1J2K3",
         f"arn:aws:lambda:us-east-1:{TEST_ACCOUNT_ID}:function:response-headers:2",
     ) in rels
+    assert check_rels(
+        neo4j_session,
+        "AWSWAFWebACL",
+        "arn",
+        "AWSCloudFrontDistribution",
+        "arn",
+        "PROTECTS",
+        rel_direction_right=True,
+    ) == {
+        (
+            web_acl_arn,
+            f"arn:aws:cloudfront::{TEST_ACCOUNT_ID}:distribution/E7F8G9H0I1J2K3",
+        ),
+    }
 
 
 @patch.object(

--- a/tests/integration/cartography/intel/aws/test_cognito.py
+++ b/tests/integration/cartography/intel/aws/test_cognito.py
@@ -125,3 +125,39 @@ def test_sync_cognito(
         (TEST_ACCOUNT_ID, "us-east-1_abc123"),
         (TEST_ACCOUNT_ID, "us-west-2_xyz789"),
     }
+
+
+@patch.object(
+    cartography.intel.aws.cognito,
+    "get_identity_pools",
+    return_value=[],
+)
+@patch.object(
+    cartography.intel.aws.cognito,
+    "get_user_pools",
+    return_value=GET_COGNITO_USER_POOLS,
+)
+def test_sync_cognito_user_pools_without_identity_pools(
+    _mock_get_user_pools,
+    _mock_get_identity_pools,
+    neo4j_session,
+):
+    # Arrange
+    neo4j_session.run("MATCH (n:AWSCognitoUserPool) DETACH DELETE n")
+    create_test_account(neo4j_session, TEST_ACCOUNT_ID, TEST_UPDATE_TAG)
+
+    # Act
+    sync(
+        neo4j_session,
+        MagicMock(),
+        [TEST_REGION],
+        TEST_ACCOUNT_ID,
+        TEST_UPDATE_TAG,
+        {"UPDATE_TAG": TEST_UPDATE_TAG, "AWS_ID": TEST_ACCOUNT_ID},
+    )
+
+    # Assert
+    assert check_nodes(neo4j_session, "AWSCognitoUserPool", ["id"]) == {
+        ("us-east-1_abc123",),
+        ("us-west-2_xyz789",),
+    }

--- a/tests/integration/cartography/intel/aws/test_resourcegroupstaggingapi.py
+++ b/tests/integration/cartography/intel/aws/test_resourcegroupstaggingapi.py
@@ -157,3 +157,46 @@ def test_sync_tags_scopes_to_correct_region(neo4j_session):
         (LOAD_BALANCERS_US_EAST_1[0]["id"], "env:prod"),
         (LOAD_BALANCERS_US_WEST_2[0]["id"], "env:staging"),
     }
+
+
+def test_cleanup_removes_stale_waf_tags(neo4j_session):
+    # Arrange
+    create_test_account(neo4j_session, TEST_ACCOUNT_ID, TEST_UPDATE_TAG)
+    neo4j_session.run(
+        """
+        MATCH (account:AWSAccount {id: $account_id})
+        MERGE (account)-[:RESOURCE]->(acl:AWSWAFWebACL {id: 'acl-1'})
+        MERGE (tag:AWSTag {id: 'env:test'})
+        MERGE (acl)-[r:TAGGED]->(tag)
+        SET tag.lastupdated = $old_update_tag,
+            r.lastupdated = $old_update_tag
+        """,
+        account_id=TEST_ACCOUNT_ID,
+        old_update_tag=TEST_UPDATE_TAG - 1,
+    )
+
+    # Act
+    rgta.cleanup(
+        neo4j_session,
+        {"UPDATE_TAG": TEST_UPDATE_TAG, "AWS_ID": TEST_ACCOUNT_ID},
+    )
+
+    # Assert
+    assert (
+        check_rels(
+            neo4j_session,
+            "AWSWAFWebACL",
+            "id",
+            "AWSTag",
+            "id",
+            "TAGGED",
+            rel_direction_right=True,
+        )
+        == set()
+    )
+    assert (
+        neo4j_session.run(
+            "MATCH (tag:AWSTag {id: 'env:test'}) RETURN count(tag) AS count",
+        ).single()["count"]
+        == 0
+    )

--- a/tests/integration/cartography/intel/aws/test_waf.py
+++ b/tests/integration/cartography/intel/aws/test_waf.py
@@ -1,0 +1,247 @@
+from unittest.mock import MagicMock
+from unittest.mock import patch
+
+import cartography.intel.aws.waf
+from cartography.intel.aws.waf import sync
+from tests.data.aws import waf as test_data
+from tests.integration.cartography.intel.aws.common import create_test_account
+from tests.integration.util import check_nodes
+from tests.integration.util import check_rels
+
+TEST_UPDATE_TAG = 123456789
+
+
+def _web_acls_for_scope(_session, _region, scope, scan_status):
+    scan_status["complete"] = True
+    return (
+        test_data.CLOUDFRONT_WEB_ACLS
+        if scope == "CLOUDFRONT"
+        else test_data.REGIONAL_WEB_ACLS
+    )
+
+
+def _logging_for_scope(_session, _region, scope, scan_status):
+    scan_status["complete"] = True
+    return test_data.LOGGING_CONFIGURATIONS if scope == "REGIONAL" else []
+
+
+def _protected_resources(_session, _region, _web_acl_arn, scan_status):
+    scan_status["complete"] = True
+    return test_data.PROTECTED_RESOURCES
+
+
+@patch.object(
+    cartography.intel.aws.waf,
+    "get_protected_resources",
+    side_effect=_protected_resources,
+)
+@patch.object(
+    cartography.intel.aws.waf,
+    "get_logging_configurations",
+    side_effect=_logging_for_scope,
+)
+@patch.object(
+    cartography.intel.aws.waf,
+    "get_web_acls",
+    side_effect=_web_acls_for_scope,
+)
+def test_sync_waf(
+    _mock_get_web_acls,
+    _mock_get_logging_configurations,
+    _mock_get_protected_resources,
+    neo4j_session,
+):
+    # Arrange
+    neo4j_session.run("MATCH (n:AWSWAFWebACL|AWSWAFRule) DETACH DELETE n")
+    create_test_account(
+        neo4j_session,
+        test_data.TEST_ACCOUNT_ID,
+        TEST_UPDATE_TAG,
+    )
+    neo4j_session.run(
+        "MERGE (:AWSLoadBalancerV2 {arn: $arn})",
+        arn=test_data.LOAD_BALANCER_ARN,
+    )
+    neo4j_session.run(
+        "MERGE (:AWSCognitoUserPool {id: $id})",
+        id="us-west-2_Example",
+    )
+    neo4j_session.run(
+        """
+        MATCH (account:AWSAccount {id: $account_id})
+        MERGE (stale:AWSWAFWebACL {id: 'stale-acl'})
+        SET stale.lastupdated = 1
+        MERGE (account)-[:RESOURCE]->(stale)
+        MERGE (stale_rule:AWSWAFRule {id: 'stale-rule'})
+        SET stale_rule.lastupdated = 1
+        MERGE (account)-[:RESOURCE]->(stale_rule)
+        MERGE (stale)-[:HAS_RULE]->(stale_rule)
+        """,
+        account_id=test_data.TEST_ACCOUNT_ID,
+    )
+
+    # Act
+    sync(
+        neo4j_session,
+        MagicMock(),
+        ["us-west-2"],
+        test_data.TEST_ACCOUNT_ID,
+        TEST_UPDATE_TAG,
+        {"UPDATE_TAG": TEST_UPDATE_TAG, "AWS_ID": test_data.TEST_ACCOUNT_ID},
+    )
+
+    # Assert
+    assert check_nodes(
+        neo4j_session,
+        "AWSWAFWebACL",
+        ["arn", "scope", "default_action", "logging_enabled", "_ont_name"],
+    ) == {
+        (
+            test_data.REGIONAL_WEB_ACL_ARN,
+            "REGIONAL",
+            "ALLOW",
+            True,
+            "regional-acl",
+        ),
+        (
+            test_data.CLOUDFRONT_WEB_ACL_ARN,
+            "CLOUDFRONT",
+            "BLOCK",
+            False,
+            "cloudfront-acl",
+        ),
+    }
+    assert check_nodes(
+        neo4j_session,
+        "AWSWAFRule",
+        ["name", "action", "override_action", "phase"],
+    ) == {
+        ("rate-limit-login", "BLOCK", None, "regular"),
+        ("aws-common-rules", None, "NONE", "regular"),
+    }
+    assert check_rels(
+        neo4j_session,
+        "AWSWAFWebACL",
+        "arn",
+        "AWSWAFRule",
+        "name",
+        "HAS_RULE",
+        rel_direction_right=True,
+    ) == {
+        (test_data.REGIONAL_WEB_ACL_ARN, "rate-limit-login"),
+        (test_data.CLOUDFRONT_WEB_ACL_ARN, "aws-common-rules"),
+    }
+    assert check_rels(
+        neo4j_session,
+        "AWSWAFWebACL",
+        "arn",
+        "AWSLoadBalancerV2",
+        "arn",
+        "PROTECTS",
+        rel_direction_right=True,
+    ) == {(test_data.REGIONAL_WEB_ACL_ARN, test_data.LOAD_BALANCER_ARN)}
+    assert check_rels(
+        neo4j_session,
+        "AWSWAFWebACL",
+        "arn",
+        "AWSCognitoUserPool",
+        "id",
+        "PROTECTS",
+        rel_direction_right=True,
+    ) == {(test_data.REGIONAL_WEB_ACL_ARN, "us-west-2_Example")}
+    assert (
+        neo4j_session.run(
+            "MATCH (n) WHERE n.id IN ['stale-acl', 'stale-rule'] RETURN count(n) AS count",
+        ).single()["count"]
+        == 0
+    )
+
+    # Act - keep the ACL but remove its regional associations.
+    def no_protected_resources(_session, _region, _web_acl_arn, scan_status):
+        scan_status["complete"] = True
+        return []
+
+    _mock_get_protected_resources.side_effect = no_protected_resources
+    sync(
+        neo4j_session,
+        MagicMock(),
+        ["us-west-2"],
+        test_data.TEST_ACCOUNT_ID,
+        TEST_UPDATE_TAG + 1,
+        {"UPDATE_TAG": TEST_UPDATE_TAG + 1, "AWS_ID": test_data.TEST_ACCOUNT_ID},
+    )
+
+    # Assert - stale PROTECTS relationships are removed while the ACL remains.
+    assert (
+        check_rels(
+            neo4j_session,
+            "AWSWAFWebACL",
+            "arn",
+            "AWSLoadBalancerV2",
+            "arn",
+            "PROTECTS",
+            rel_direction_right=True,
+        )
+        == set()
+    )
+
+
+@patch.object(
+    cartography.intel.aws.waf,
+    "get_protected_resources",
+    side_effect=_protected_resources,
+)
+@patch.object(
+    cartography.intel.aws.waf,
+    "get_logging_configurations",
+    side_effect=_logging_for_scope,
+)
+@patch.object(cartography.intel.aws.waf, "get_web_acls")
+def test_sync_waf_preserves_previous_data_after_incomplete_scan(
+    mock_get_web_acls,
+    _mock_get_logging_configurations,
+    _mock_get_protected_resources,
+    neo4j_session,
+):
+    # Arrange
+    neo4j_session.run("MATCH (n:AWSWAFWebACL|AWSWAFRule) DETACH DELETE n")
+    create_test_account(
+        neo4j_session,
+        test_data.TEST_ACCOUNT_ID,
+        TEST_UPDATE_TAG,
+    )
+    neo4j_session.run(
+        """
+        MATCH (account:AWSAccount {id: $account_id})
+        MERGE (account)-[:RESOURCE]->(acl:AWSWAFWebACL {id: 'previous-acl'})
+        SET acl.lastupdated = $previous_update_tag
+        """,
+        account_id=test_data.TEST_ACCOUNT_ID,
+        previous_update_tag=TEST_UPDATE_TAG - 1,
+    )
+
+    def one_region_fails(_session, region, scope, scan_status):
+        if region == "us-east-2":
+            return []
+        scan_status["complete"] = True
+        if scope == "REGIONAL":
+            return test_data.REGIONAL_WEB_ACLS
+        return []
+
+    mock_get_web_acls.side_effect = one_region_fails
+
+    # Act
+    sync(
+        neo4j_session,
+        MagicMock(),
+        ["us-west-2", "us-east-2"],
+        test_data.TEST_ACCOUNT_ID,
+        TEST_UPDATE_TAG,
+        {"UPDATE_TAG": TEST_UPDATE_TAG, "AWS_ID": test_data.TEST_ACCOUNT_ID},
+    )
+
+    # Assert
+    assert check_nodes(neo4j_session, "AWSWAFWebACL", ["id"]) >= {
+        ("previous-acl",),
+        (test_data.REGIONAL_WEB_ACLS[0]["ARN"],),
+    }

--- a/tests/unit/cartography/intel/aws/test_resourcegroupstaggingapi.py
+++ b/tests/unit/cartography/intel/aws/test_resourcegroupstaggingapi.py
@@ -51,6 +51,12 @@ def test_get_resource_type_from_arn():
     assert "elasticloadbalancing:loadbalancer/app" == rgta.get_resource_type_from_arn(
         "arn:aws:elasticloadbalancing:us-east-1:1234:loadbalancer/app/foo/123"
     )
+    assert "wafv2:webacl" == rgta.get_resource_type_from_arn(
+        "arn:aws:wafv2:us-east-1:1234:global/webacl/foo/123"
+    )
+    assert "wafv2:webacl" == rgta.get_resource_type_from_arn(
+        "arn:aws:wafv2:us-west-2:1234:regional/webacl/foo/123"
+    )
 
 
 def test_group_tag_data_by_resource_type():
@@ -237,3 +243,6 @@ def test_every_declared_arn_parser_resolves():
     assert set(rgta.TAG_RESOURCE_TYPE_MAPPINGS) == {
         resource.resource_type for resource in AWS_TAGGABLE_RESOURCES
     }
+    assert {
+        resource.label for resource in AWS_TAGGABLE_RESOURCES
+    } <= rgta._RESOURCE_CLEANUP_PATHS.keys()

--- a/tests/unit/cartography/intel/aws/test_resources.py
+++ b/tests/unit/cartography/intel/aws/test_resources.py
@@ -52,3 +52,18 @@ def test_analysis_dependency_sets_include_all_required_producers():
     # Assert
     assert actual_dependencies == expected_dependencies
     assert "ec2:autoscalinggroup" in AWS_EC2_ASSET_EXPOSURE_AUTO_SCALING_GROUP_DEPS
+
+
+def test_waf_sync_order_satisfies_protected_resource_relationships():
+    # Arrange
+    resource_order = list(RESOURCE_FUNCTIONS)
+
+    # Act
+    waf_index = resource_order.index("waf")
+
+    # Assert
+    assert resource_order.index("ec2:load_balancer_v2") < waf_index
+    assert resource_order.index("cognito") < waf_index
+    assert waf_index < resource_order.index("resourcegroupstaggingapi")
+    assert waf_index < resource_order.index("apigateway")
+    assert waf_index < resource_order.index("cloudfront")

--- a/tests/unit/cartography/intel/aws/test_waf.py
+++ b/tests/unit/cartography/intel/aws/test_waf.py
@@ -1,0 +1,116 @@
+from unittest.mock import MagicMock
+from unittest.mock import patch
+
+import cartography.intel.aws.waf
+from cartography.intel.aws.waf import _list_with_marker
+from cartography.intel.aws.waf import sync
+from cartography.intel.aws.waf import transform
+from tests.data.aws import waf as test_data
+
+
+def test_list_with_marker_collects_every_page():
+    # Arrange
+    client = MagicMock()
+    client.list_web_acls.side_effect = [
+        {"WebACLs": [{"ARN": "first"}], "NextMarker": "page-2"},
+        {"WebACLs": [{"ARN": "second"}]},
+    ]
+
+    # Act
+    result = _list_with_marker(
+        client,
+        "list_web_acls",
+        "WebACLs",
+        Scope="REGIONAL",
+    )
+
+    # Assert
+    assert result == [{"ARN": "first"}, {"ARN": "second"}]
+
+
+def test_transform_extracts_nested_rule_and_logging_metadata():
+    # Arrange
+    protected_resources = {
+        test_data.REGIONAL_WEB_ACL_ARN: test_data.PROTECTED_RESOURCES,
+    }
+
+    # Act
+    web_acls, rules = transform(
+        test_data.REGIONAL_WEB_ACLS,
+        test_data.LOGGING_CONFIGURATIONS,
+        protected_resources,
+        "us-west-2",
+        "REGIONAL",
+    )
+
+    # Assert
+    assert web_acls[0]["DefaultAction"] == "ALLOW"
+    assert web_acls[0]["LoggingEnabled"] is True
+    assert web_acls[0]["RedactedFieldTypes"] == ["SingleHeader"]
+    assert web_acls[0]["ProtectedLoadBalancerArns"] == [
+        test_data.LOAD_BALANCER_ARN,
+    ]
+    assert web_acls[0]["ProtectedCognitoUserPoolIds"] == ["us-west-2_Example"]
+    assert rules[0]["Action"] == "BLOCK"
+    assert rules[0]["StatementTypes"] == [
+        "RateBasedStatement",
+        "ScopeDownStatement",
+        "IPSetReferenceStatement",
+    ]
+    assert rules[0]["ReferencedIPSetArns"] == [
+        f"arn:aws:wafv2:us-west-2:{test_data.TEST_ACCOUNT_ID}:regional/ipset/office/ipset-1",
+    ]
+    assert rules[0]["RateLimits"] == [100]
+
+
+@patch.object(cartography.intel.aws.waf, "cleanup")
+@patch.object(cartography.intel.aws.waf, "get_web_acls", return_value=[])
+def test_sync_skips_cleanup_after_incomplete_scan(
+    _mock_get_web_acls,
+    mock_cleanup,
+):
+    # Arrange
+    neo4j_session = MagicMock()
+
+    # Act
+    sync(
+        neo4j_session,
+        MagicMock(),
+        ["us-west-2"],
+        test_data.TEST_ACCOUNT_ID,
+        123456789,
+        {"UPDATE_TAG": 123456789, "AWS_ID": test_data.TEST_ACCOUNT_ID},
+    )
+
+    # Assert
+    mock_cleanup.assert_not_called()
+
+
+@patch.object(cartography.intel.aws.waf, "cleanup")
+@patch.object(cartography.intel.aws.waf, "get_logging_configurations")
+@patch.object(cartography.intel.aws.waf, "get_web_acls")
+def test_sync_skips_logging_lookup_when_scope_has_no_web_acls(
+    mock_get_web_acls,
+    mock_get_logging_configurations,
+    mock_cleanup,
+):
+    # Arrange
+    def complete_empty_scan(_session, _region, _scope, scan_status):
+        scan_status["complete"] = True
+        return []
+
+    mock_get_web_acls.side_effect = complete_empty_scan
+
+    # Act
+    sync(
+        MagicMock(),
+        MagicMock(),
+        ["us-west-2"],
+        test_data.TEST_ACCOUNT_ID,
+        123456789,
+        {"UPDATE_TAG": 123456789, "AWS_ID": test_data.TEST_ACCOUNT_ID},
+    )
+
+    # Assert
+    mock_get_logging_configurations.assert_not_called()
+    mock_cleanup.assert_called_once()

--- a/tests/unit/cartography/models/test_introspection.py
+++ b/tests/unit/cartography/models/test_introspection.py
@@ -408,7 +408,7 @@ def test_build_data_model_exposes_ontology_catalog_metadata():
         )
         for constraint in model.ontology_relationship_constraints
     }
-    assert len(constraints) == 46
+    assert len(constraints) == 47
     assert ("ComputePod", "USES_SECRET", "Secret") in constraints
     assert ("Container", "RESOLVED_IMAGE", "Image") in constraints
     assert ("Container", "SCANNED_AS", "FilesystemSnapshot") in constraints


### PR DESCRIPTION
### Type of change
- [ ] Bug fix (non-breaking change that fixes an issue)
- [x] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Refactoring (no functional changes)
- [x] Documentation update
- [ ] Other (please describe):

### Summary
Add AWS WAFv2 inventory for regional and CloudFront scopes.

The connector loads web ACLs and rules, models web ACLs as network access controls, and links protected Application Load Balancers, Cognito user pools, API Gateway stages, and CloudFront distributions. It also captures logging configuration, rule metadata, AWS tags, pagination, dependency ordering, and conservative cleanup after complete scans.

### Related issues or links
None.

### How was this tested?
- make test
  - full lint and unit suite
  - 1,612 integration tests passed
- focused WAF and affected AWS model tests: 78 passed
- uv run --group doc ./docs/build.sh
- real AWS validation is intentionally pending; this draft documents the proposed isolated staging validation before any cloud resources are created

### Checklist

#### General
- [x] I have read the contributing guidelines.
- [x] The linter passes locally (make test_lint).
- [x] I have added/updated tests that prove my feature works.
- [x] Every commit includes a DCO Signed-off-by trailer.

#### Proof of functionality
- [ ] Screenshot showing the graph before and after changes.
- [x] New or updated unit/integration tests.

#### If you are adding or modifying an intel connector
- [ ] Tested the connector against a real cloud, SaaS, or provider environment.
- [ ] Included sanitized Cartography sync logs demonstrating successful synchronization.

#### If you are changing a node or relationship
- [x] Updated model docstrings and PropertyRef.description values used to generate schema documentation.
- [x] Built the documentation with uv run --group doc ./docs/build.sh.

#### If you are implementing a new intel module
- [x] Used the NodeSchema data model.

### Notes for reviewers
The sync deliberately skips account-scoped cleanup if any configured WAF scope is incomplete, preventing transient regional or permission failures from deleting previously observed data. API Gateway and CloudFront associations come from their native service APIs; WAF ListResourcesForWebACL is used for currently modeled regional target types.

This remains a draft until sanitized real-environment evidence is attached.
