### PR TITLE
fix(container-images): batch layer-cache reads

### DIFF
--- a/cartography/intel/container_image_layers.py
+++ b/cartography/intel/container_image_layers.py
@@ -79,9 +79,13 @@ def get_complete_layer_digests(
     shape: ContainerImageLayerGraphShape,
     digests: Iterable[str] | None,
     scope_values: Mapping[str, Any],
+    *,
+    batch_size: int = 500,
 ) -> set[str]:
     """Return digests whose layer closure is complete for the current scope."""
 
+    if batch_size <= 0:
+        raise ValueError("batch_size must be greater than zero")
     unique_digests = sorted(set(digests)) if digests is not None else None
     if unique_digests == []:
         return set()
@@ -185,13 +189,22 @@ def get_complete_layer_digests(
       {relationship_predicate}
     RETURN img.{shape.image_digest_property}
     """
-    values = neo4j_session.execute_read(
-        read_list_of_values_tx,
-        query,
-        **({"digests": unique_digests} if unique_digests is not None else {}),
-        **parameters,
-    )
-    return {str(value) for value in values if value}
+    # Large IN lists can exhaust Neo4j's heap even when no layers are cached.
+    digest_batches: Iterable[list[str] | None]
+    if unique_digests is None:
+        digest_batches = [None]
+    else:
+        digest_batches = batch(unique_digests, size=batch_size)
+    complete_digests: set[str] = set()
+    for digest_batch in digest_batches:
+        values = neo4j_session.execute_read(
+            read_list_of_values_tx,
+            query,
+            **({"digests": digest_batch} if digest_batch is not None else {}),
+            **parameters,
+        )
+        complete_digests.update(str(value) for value in values if value)
+    return complete_digests
 
 
 def partition_layer_fetches(

--- a/tests/integration/cartography/intel/test_container_image_layers.py
+++ b/tests/integration/cartography/intel/test_container_image_layers.py
@@ -1,0 +1,69 @@
+import pytest
+
+from cartography.intel.container_image_layers import get_complete_layer_digests
+from cartography.intel.gcp.artifact_registry.supply_chain import (
+    GCP_ARTIFACT_REGISTRY_LAYER_GRAPH,
+)
+
+
+@pytest.mark.parametrize("batch_size", [1, 2, 500])
+def test_get_complete_layer_digests_preserves_completeness_and_scope(
+    neo4j_session, batch_size
+):
+    # Arrange
+    neo4j_session.run("MATCH (n) DETACH DELETE n").consume()
+    neo4j_session.run(
+        """
+        CREATE (project:GCPProject {id: 'project-1'}),
+               (other:GCPProject {id: 'project-2'}),
+               (project)-[:RESOURCE]->(:GCPArtifactRegistryImageLayer {id: 'local'}),
+               (other)-[:RESOURCE]->(:GCPArtifactRegistryImageLayer {id: 'foreign'})
+        WITH project
+        UNWIND $images AS image
+        CREATE (project)-[:RESOURCE]->(:GCPArtifactRegistryImage {
+            digest: image.digest, layer_diff_ids: image.layers
+        })
+        """,
+        images=[
+            {"digest": "sha256:0", "layers": ["local"]},
+            {"digest": "sha256:1", "layers": None},
+            {"digest": "sha256:2", "layers": []},
+            {"digest": "sha256:3", "layers": ["local", "missing"]},
+            {"digest": "sha256:4", "layers": ["foreign"]},
+            {"digest": "sha256:5", "layers": ["local"]},
+        ],
+    ).consume()
+
+    # Act
+    result = get_complete_layer_digests(
+        neo4j_session,
+        GCP_ARTIFACT_REGISTRY_LAYER_GRAPH,
+        [f"sha256:{index}" for index in range(7)],
+        {"id": "project-1"},
+        batch_size=batch_size,
+    )
+
+    # Assert
+    assert result == {"sha256:0", "sha256:2", "sha256:5"}
+
+
+def test_get_complete_layer_digests_with_empty_cache(neo4j_session):
+    # Arrange
+    neo4j_session.run("MATCH (n) DETACH DELETE n").consume()
+    neo4j_session.run(
+        """
+        UNWIND range(0, 500) AS i
+        CREATE (:GCPArtifactRegistryImage {digest: 'sha256:' + toString(i)})
+        """
+    ).consume()
+
+    # Act
+    result = get_complete_layer_digests(
+        neo4j_session,
+        GCP_ARTIFACT_REGISTRY_LAYER_GRAPH,
+        (f"sha256:{index}" for index in range(501)),
+        {"id": "project-1"},
+    )
+
+    # Assert
+    assert result == set()

--- a/tests/unit/cartography/intel/test_container_image_layers.py
+++ b/tests/unit/cartography/intel/test_container_image_layers.py
@@ -140,3 +140,72 @@ def test_refresh_layer_closures_rejects_invalid_batch_size():
             456,
             batch_size=0,
         )
+
+
+@pytest.mark.parametrize("count", [0, 1, 500, 501, 1201])
+def test_get_complete_layer_digests_bounds_queries_and_combines_results(count):
+    # Arrange
+    digests = [f"sha256:{index:04}" for index in range(count)]
+    cached = set(digests[::3])
+    neo4j_session = MagicMock()
+    neo4j_session.execute_read.side_effect = lambda _, query, **params: [
+        digest for digest in params["digests"] if digest in cached
+    ]
+
+    # Act
+    result = get_complete_layer_digests(
+        neo4j_session,
+        TEST_SHAPE,
+        iter(digests + digests),
+        {"id": "tenant-1"},
+    )
+
+    # Assert
+    assert result == cached
+    calls = neo4j_session.execute_read.call_args_list
+    assert len(calls) == (count + 499) // 500
+    assert all(0 < len(call.kwargs["digests"]) <= 500 for call in calls)
+    assert [digest for call in calls for digest in call.kwargs["digests"]] == digests
+    assert all(call.kwargs["scope_id"] == "tenant-1" for call in calls)
+
+
+def test_get_complete_layer_digests_preserves_whole_scope_lookup():
+    # Arrange
+    neo4j_session = MagicMock()
+    neo4j_session.execute_read.return_value = ["sha256:cached"]
+
+    # Act
+    result = get_complete_layer_digests(
+        neo4j_session, TEST_SHAPE, None, {"id": "tenant-1"}
+    )
+
+    # Assert
+    assert result == {"sha256:cached"}
+    neo4j_session.execute_read.assert_called_once()
+    assert neo4j_session.execute_read.call_args.kwargs == {"scope_id": "tenant-1"}
+    assert "$digests" not in neo4j_session.execute_read.call_args.args[1]
+
+
+def test_get_complete_layer_digests_propagates_later_batch_failure():
+    # Arrange
+    neo4j_session = MagicMock()
+    neo4j_session.execute_read.side_effect = [["sha256:cached"], RuntimeError("failed")]
+
+    # Act and assert
+    with pytest.raises(RuntimeError, match="failed"):
+        get_complete_layer_digests(
+            neo4j_session,
+            TEST_SHAPE,
+            ["sha256:cached", "sha256:other"],
+            {"id": "tenant-1"},
+            batch_size=1,
+        )
+
+
+@pytest.mark.parametrize("batch_size", [0, -1])
+def test_get_complete_layer_digests_rejects_invalid_batch_size(batch_size):
+    # Act and assert
+    with pytest.raises(ValueError, match="batch_size"):
+        get_complete_layer_digests(
+            MagicMock(), TEST_SHAPE, [], {"id": "tenant-1"}, batch_size=batch_size
+        )


### PR DESCRIPTION
### Type of change
- [x] Bug fix (non-breaking change that fixes an issue)

### Summary
Large registry syncs can exhaust Neo4j's heap while checking cached image layers, even when the cache is empty. Batch explicit digest lookups in groups of 500, preserving completeness checks, scope filters, and the existing whole-scope lookup used by GitHub and GitLab.

### Related issues or links
- Follow-up to #3092, prompted by a production GCP sync failure.

### How was this tested?
- 136 unit tests and 48 Neo4j integration tests across the shared helper and all five registry callers; `make test_lint`.
- Synthetic Neo4j 2025.10 Enterprise, 512 MB heap, 100,000 images: the original helper OOMs on 500,000 candidate digests; this patch returns the expected empty result in 7.9s / 4.0s. The new batch-boundary regression also fails against the original helper.

### Checklist
#### General
- [x] I have read the contributing guidelines.
- [x] The linter passes locally (`make test_lint`).
- [x] I have added/updated tests that prove my fix is effective.
- [x] Every commit includes a DCO `Signed-off-by` trailer.

#### Proof of functionality
- [x] New or updated unit/integration tests.

