### PR TITLE
Connect GKE and Kubernetes inventory, workload identity, and load balancers

### DIFF
--- a/cartography/analysis/gcp/analysis.py
+++ b/cartography/analysis/gcp/analysis.py
@@ -32,7 +32,7 @@ GCP_GKE_ASSET_EXPOSURE = AnalysisJob(
     short_name="gcp_gke_asset_exposure",
     statements=(
         AnalysisStatement(
-            match="MATCH (cluster:GKECluster) WHERE cluster.private_nodes = false OR cluster.private_endpoint_enabled = false OR cluster.master_authorized_networks = false",
+            match="MATCH (cluster:GKECluster) WHERE cluster.control_plane_public_access = true OR (cluster.control_plane_public_access IS NULL AND (cluster.private_nodes = false OR cluster.private_endpoint_enabled = false OR cluster.master_authorized_networks = false))",
             effects=(
                 SetProperty("cluster", "exposed_internet", True, label="GKECluster"),
             ),

--- a/cartography/analysis/kubernetes/analysis.py
+++ b/cartography/analysis/kubernetes/analysis.py
@@ -11,11 +11,11 @@ K8S_SERVICE_ASSET_EXPOSURE = AnalysisJob(
     scope=ScopeById(
         "KubernetesCluster",
         "CLUSTER_ID",
-        scope_on=("svc", "ing"),
+        scope_on=("svc", "ing", "gw"),
     ),
     statements=(
         AnalysisStatement(
-            match="MATCH (svc:KubernetesService)-[:USES_LOAD_BALANCER]->(lb:AWSLoadBalancerV2) WHERE lb.exposed_internet = true OR (lb.scheme = 'internet-facing' AND lb.type = 'network') WITH DISTINCT svc",
+            match="MATCH (svc:KubernetesService)-[:USES_LOAD_BALANCER]->(lb:LoadBalancer) WHERE lb.exposed_internet = true OR (lb.scheme = 'internet-facing' AND lb.type = 'network') WITH DISTINCT svc",
             effects=(
                 SetProperty("svc", "exposed_internet", True, label="KubernetesService"),
                 AddToSet(
@@ -24,7 +24,16 @@ K8S_SERVICE_ASSET_EXPOSURE = AnalysisJob(
             ),
         ),
         AnalysisStatement(
-            match="MATCH (ing:KubernetesIngress)-[:USES_LOAD_BALANCER]->(lb:AWSLoadBalancerV2) WHERE lb.exposed_internet = true OR (lb.scheme = 'internet-facing' AND lb.type = 'network') MATCH (ing)-[:TARGETS]->(svc:KubernetesService) WITH DISTINCT svc",
+            match="MATCH (ing:KubernetesIngress)-[:USES_LOAD_BALANCER]->(lb:LoadBalancer) WHERE lb.exposed_internet = true OR (lb.scheme = 'internet-facing' AND lb.type = 'network') MATCH (ing)-[:TARGETS]->(svc:KubernetesService) WITH DISTINCT svc",
+            effects=(
+                SetProperty("svc", "exposed_internet", True, label="KubernetesService"),
+                AddToSet(
+                    "svc", "exposed_internet_type", "lb", label="KubernetesService"
+                ),
+            ),
+        ),
+        AnalysisStatement(
+            match="MATCH (gw:KubernetesGateway)-[:USES_LOAD_BALANCER]->(lb:LoadBalancer) WHERE lb.exposed_internet = true OR (lb.scheme = 'internet-facing' AND lb.type = 'network') MATCH (gw)-[:ROUTES]->(:KubernetesHTTPRoute)-[:TARGETS]->(svc:KubernetesService) WITH DISTINCT svc",
             effects=(
                 SetProperty("svc", "exposed_internet", True, label="KubernetesService"),
                 AddToSet(
@@ -75,32 +84,46 @@ K8S_LB_POD_EXPOSURE = AnalysisJob(
     scope=ScopeById(
         "KubernetesCluster",
         "CLUSTER_ID",
-        scope_on=("svc", "ing"),
+        scope_on=("svc", "ing", "gw"),
     ),
     statements=(
         AnalysisStatement(
-            match="MATCH (svc:KubernetesService)-[:USES_LOAD_BALANCER]->(lb:AWSLoadBalancerV2) WHERE lb.exposed_internet = true OR (lb.scheme = 'internet-facing' AND lb.type = 'network') MATCH (svc)-[:TARGETS]->(pod:KubernetesPod)",
+            match="MATCH (svc:KubernetesService)-[:USES_LOAD_BALANCER]->(lb:LoadBalancer) WHERE lb.exposed_internet = true OR (lb.scheme = 'internet-facing' AND lb.type = 'network') MATCH (svc)-[:TARGETS]->(pod:KubernetesPod)",
             effects=(
                 AddRelationship(
                     "lb",
                     "EXPOSE",
                     "pod",
                     properties={"exposure_type": "via_lb_only"},
-                    source_label="AWSLoadBalancerV2",
+                    source_label="LoadBalancer",
                     target_label="KubernetesPod",
                     scoped_to="target",
                 ),
             ),
         ),
         AnalysisStatement(
-            match="MATCH (ing:KubernetesIngress)-[:USES_LOAD_BALANCER]->(lb:AWSLoadBalancerV2) WHERE lb.exposed_internet = true OR (lb.scheme = 'internet-facing' AND lb.type = 'network') MATCH (ing)-[:TARGETS]->(svc:KubernetesService)-[:TARGETS]->(pod:KubernetesPod)",
+            match="MATCH (ing:KubernetesIngress)-[:USES_LOAD_BALANCER]->(lb:LoadBalancer) WHERE lb.exposed_internet = true OR (lb.scheme = 'internet-facing' AND lb.type = 'network') MATCH (ing)-[:TARGETS]->(svc:KubernetesService)-[:TARGETS]->(pod:KubernetesPod)",
             effects=(
                 AddRelationship(
                     "lb",
                     "EXPOSE",
                     "pod",
                     properties={"exposure_type": "via_lb_only"},
-                    source_label="AWSLoadBalancerV2",
+                    source_label="LoadBalancer",
+                    target_label="KubernetesPod",
+                    scoped_to="target",
+                ),
+            ),
+        ),
+        AnalysisStatement(
+            match="MATCH (gw:KubernetesGateway)-[:USES_LOAD_BALANCER]->(lb:LoadBalancer) WHERE lb.exposed_internet = true OR (lb.scheme = 'internet-facing' AND lb.type = 'network') MATCH (gw)-[:ROUTES]->(:KubernetesHTTPRoute)-[:TARGETS]->(svc:KubernetesService)-[:TARGETS]->(pod:KubernetesPod)",
+            effects=(
+                AddRelationship(
+                    "lb",
+                    "EXPOSE",
+                    "pod",
+                    properties={"exposure_type": "via_lb_only"},
+                    source_label="LoadBalancer",
                     target_label="KubernetesPod",
                     scoped_to="target",
                 ),
@@ -114,32 +137,46 @@ K8S_LB_CONTAINER_EXPOSURE = AnalysisJob(
     scope=ScopeById(
         "KubernetesCluster",
         "CLUSTER_ID",
-        scope_on=("svc", "ing"),
+        scope_on=("svc", "ing", "gw"),
     ),
     statements=(
         AnalysisStatement(
-            match="MATCH (svc:KubernetesService)-[:USES_LOAD_BALANCER]->(lb:AWSLoadBalancerV2) WHERE lb.exposed_internet = true OR (lb.scheme = 'internet-facing' AND lb.type = 'network') MATCH (svc)-[:TARGETS]->(pod:KubernetesPod)-[:CONTAINS]->(c:KubernetesContainer)",
+            match="MATCH (svc:KubernetesService)-[:USES_LOAD_BALANCER]->(lb:LoadBalancer) WHERE lb.exposed_internet = true OR (lb.scheme = 'internet-facing' AND lb.type = 'network') MATCH (svc)-[:TARGETS]->(pod:KubernetesPod)-[:CONTAINS]->(c:KubernetesContainer)",
             effects=(
                 AddRelationship(
                     "lb",
                     "EXPOSE",
                     "c",
                     properties={"exposure_type": "via_lb_only"},
-                    source_label="AWSLoadBalancerV2",
+                    source_label="LoadBalancer",
                     target_label="KubernetesContainer",
                     scoped_to="target",
                 ),
             ),
         ),
         AnalysisStatement(
-            match="MATCH (ing:KubernetesIngress)-[:USES_LOAD_BALANCER]->(lb:AWSLoadBalancerV2) WHERE lb.exposed_internet = true OR (lb.scheme = 'internet-facing' AND lb.type = 'network') MATCH (ing)-[:TARGETS]->(svc:KubernetesService)-[:TARGETS]->(pod:KubernetesPod)-[:CONTAINS]->(c:KubernetesContainer)",
+            match="MATCH (ing:KubernetesIngress)-[:USES_LOAD_BALANCER]->(lb:LoadBalancer) WHERE lb.exposed_internet = true OR (lb.scheme = 'internet-facing' AND lb.type = 'network') MATCH (ing)-[:TARGETS]->(svc:KubernetesService)-[:TARGETS]->(pod:KubernetesPod)-[:CONTAINS]->(c:KubernetesContainer)",
             effects=(
                 AddRelationship(
                     "lb",
                     "EXPOSE",
                     "c",
                     properties={"exposure_type": "via_lb_only"},
-                    source_label="AWSLoadBalancerV2",
+                    source_label="LoadBalancer",
+                    target_label="KubernetesContainer",
+                    scoped_to="target",
+                ),
+            ),
+        ),
+        AnalysisStatement(
+            match="MATCH (gw:KubernetesGateway)-[:USES_LOAD_BALANCER]->(lb:LoadBalancer) WHERE lb.exposed_internet = true OR (lb.scheme = 'internet-facing' AND lb.type = 'network') MATCH (gw)-[:ROUTES]->(:KubernetesHTTPRoute)-[:TARGETS]->(svc:KubernetesService)-[:TARGETS]->(pod:KubernetesPod)-[:CONTAINS]->(c:KubernetesContainer)",
+            effects=(
+                AddRelationship(
+                    "lb",
+                    "EXPOSE",
+                    "c",
+                    properties={"exposure_type": "via_lb_only"},
+                    source_label="LoadBalancer",
                     target_label="KubernetesContainer",
                     scoped_to="target",
                 ),

--- a/cartography/cli.py
+++ b/cartography/cli.py
@@ -1157,11 +1157,38 @@ class CLI:
                     hidden=PANEL_KUBERNETES not in visible_panels,
                 ),
             ] = None,
+            gke_clusters: Annotated[
+                list[str] | None,
+                typer.Option(
+                    "--gke-cluster",
+                    help="GKE resource name (projects/PROJECT/locations/LOCATION/clusters/NAME). Repeat for multiple clusters. Uses Google ADC without kubeconfig.",
+                    rich_help_panel=PANEL_KUBERNETES,
+                    hidden=PANEL_KUBERNETES not in visible_panels,
+                ),
+            ] = None,
+            gke_endpoint: Annotated[
+                str,
+                typer.Option(
+                    "--gke-endpoint",
+                    help="GKE API endpoint: dns, private, or public. No automatic fallback.",
+                    rich_help_panel=PANEL_KUBERNETES,
+                    hidden=PANEL_KUBERNETES not in visible_panels,
+                ),
+            ] = "dns",
+            gke_impersonate_service_account: Annotated[
+                str | None,
+                typer.Option(
+                    "--gke-impersonate-service-account",
+                    help="Service account email to impersonate for GKE discovery and Kubernetes reads.",
+                    rich_help_panel=PANEL_KUBERNETES,
+                    hidden=PANEL_KUBERNETES not in visible_panels,
+                ),
+            ] = None,
             managed_kubernetes: Annotated[
                 str | None,
                 typer.Option(
                     "--managed-kubernetes",
-                    help="Type of managed Kubernetes service (e.g., 'eks').",
+                    help="Type of managed Kubernetes service ('eks' or 'gke').",
                     rich_help_panel=PANEL_KUBERNETES,
                     hidden=PANEL_KUBERNETES not in visible_panels,
                 ),
@@ -3652,6 +3679,9 @@ class CLI:
                 huntress_api_secret=huntress_api_secret,
                 k8s_kubeconfig=k8s_kubeconfig,
                 managed_kubernetes=managed_kubernetes,
+                gke_clusters=gke_clusters,
+                gke_endpoint=gke_endpoint,
+                gke_impersonate_service_account=gke_impersonate_service_account,
                 statsd_enabled=statsd_enabled,
                 statsd_prefix=statsd_prefix,
                 statsd_host=statsd_host,

--- a/cartography/config.py
+++ b/cartography/config.py
@@ -577,6 +577,9 @@ class Config:
         huntress_api_secret=None,
         k8s_kubeconfig=None,
         managed_kubernetes=None,
+        gke_clusters=None,
+        gke_endpoint="dns",
+        gke_impersonate_service_account=None,
         statsd_enabled=False,
         statsd_prefix=None,
         statsd_host=None,
@@ -835,6 +838,9 @@ class Config:
         self.huntress_api_secret = huntress_api_secret
         self.k8s_kubeconfig = k8s_kubeconfig
         self.managed_kubernetes = managed_kubernetes
+        self.gke_clusters = gke_clusters
+        self.gke_endpoint = gke_endpoint
+        self.gke_impersonate_service_account = gke_impersonate_service_account
         self.statsd_enabled = statsd_enabled
         self.statsd_prefix = statsd_prefix
         self.statsd_host = statsd_host

--- a/cartography/intel/gcp/gke.py
+++ b/cartography/intel/gcp/gke.py
@@ -9,18 +9,20 @@ from googleapiclient.discovery import Resource
 
 from cartography.client.core.tx import load
 from cartography.graph.job import GraphJob
+from cartography.intel.gcp.gke_utils import parse_cluster_ref
 from cartography.intel.gcp.labels import sync_labels
 from cartography.intel.gcp.util import classify_gcp_http_error
 from cartography.intel.gcp.util import gcp_api_execute_with_retry
 from cartography.intel.gcp.util import summarize_gcp_http_error
 from cartography.models.gcp.gke import GCPGKEClusterSchema
+from cartography.models.gcp.gke import GKENodePoolSchema
 from cartography.util import timeit
 
 logger = logging.getLogger(__name__)
 
 
 @timeit
-def get_gke_clusters(container: Resource, project_id: str) -> Dict:
+def get_gke_clusters(container: Resource, project_id: str) -> Dict | None:
     """
     Returns a GCP response object containing a list of GKE clusters within the given project.
 
@@ -35,9 +37,20 @@ def get_gke_clusters(container: Resource, project_id: str) -> Dict:
     """
     try:
         req = (
-            container.projects().zones().clusters().list(projectId=project_id, zone="-")
+            container.projects()
+            .locations()
+            .clusters()
+            .list(parent=f"projects/{project_id}/locations/-")
         )
         res = gcp_api_execute_with_retry(req)
+        if res.get("missingZones"):
+            raise RuntimeError("GKE cluster discovery was incomplete (missing zones)")
+        res.setdefault("clusters", [])
+        for cluster in res["clusters"]:
+            reference = parse_cluster_ref(cluster["selfLink"])
+            cluster["resource_name"] = (
+                f"projects/{project_id}/locations/{reference.location}/clusters/{reference.name}"
+            )
         return res
     except HttpError as e:
         if classify_gcp_http_error(e) in (
@@ -50,10 +63,7 @@ def get_gke_clusters(container: Resource, project_id: str) -> Dict:
                 project_id,
                 summarize_gcp_http_error(e),
             )
-            # Returning empty results on permission/API-disabled errors is intentional:
-            # it allows the cleanup step to remove previously ingested data when access
-            # to this project is lost, so the graph reflects only the current visible state.
-            return {}
+            return None
         raise
 
 
@@ -81,11 +91,13 @@ def load_gke_clusters(
     )
 
 
-def _process_network_policy(cluster: Dict) -> bool:
+def _process_network_policy(cluster: Dict) -> str | bool:
     """
     Parse cluster.networkPolicy to verify if
     the provider has been enabled.
     """
+    if cluster.get("networkConfig", {}).get("datapathProvider") == "ADVANCED_DATAPATH":
+        return "DATAPLANE_V2"
     provider = cluster.get("networkPolicy", {}).get("provider")
     enabled = cluster.get("networkPolicy", {}).get("enabled")
     if provider and enabled is True:
@@ -137,6 +149,8 @@ def sync_gke_clusters(
     """
     logger.info("Syncing GKE clusters for project %s.", project_id)
     gke_res = get_gke_clusters(container, project_id)
+    if gke_res is None:
+        return
     clusters = transform_gke_clusters(gke_res)
     if clusters:
         load(
@@ -154,6 +168,16 @@ def sync_gke_clusters(
         gcp_update_tag,
         common_job_parameters,
     )
+    load(
+        neo4j_session,
+        GKENodePoolSchema(),
+        transform_node_pools(gke_res),
+        lastupdated=gcp_update_tag,
+        PROJECT_ID=project_id,
+    )
+    GraphJob.from_node_schema(GKENodePoolSchema(), common_job_parameters).run(
+        neo4j_session
+    )
     cleanup_gke_clusters(neo4j_session, common_job_parameters)
 
 
@@ -163,9 +187,69 @@ def transform_gke_clusters(api_result: Dict[str, Any]) -> List[Dict[str, Any]]:
     """
     result: List[Dict[str, Any]] = []
     for c in api_result.get("clusters", []):
+        ref = parse_cluster_ref(c.get("resource_name") or c["selfLink"])
+        endpoints = c.get("controlPlaneEndpointsConfig") or {}
+        ip = endpoints.get("ipEndpointsConfig")
+        dns = endpoints.get("dnsEndpointConfig") or {}
+        net = c.get("networkConfig") or {}
         transformed: Dict[str, Any] = {
             # Required fields
             "id": c["selfLink"],
+            "resource_name": ref.resource_name,
+            "project_id": ref.project,
+            "gke_uid": c.get("id"),
+            "autopilot_enabled": (c.get("autopilot") or {}).get("enabled", False),
+            "workload_pool": (c.get("workloadIdentityConfig") or {}).get(
+                "workloadPool"
+            ),
+            "network_uri": net.get("network")
+            or (
+                f"projects/{ref.project}/global/networks/{c['network']}"
+                if c.get("network") and "/" not in c["network"]
+                else c.get("network")
+            ),
+            "datapath_provider": net.get("datapathProvider"),
+            "dns_endpoint": dns.get("endpoint"),
+            "dns_endpoint_enabled": (
+                dns.get("allowExternalTraffic", False)
+                if "dnsEndpointConfig" in endpoints
+                else None
+            ),
+            "dns_allow_kubernetes_tokens": (
+                dns.get("enableK8sTokensViaDns", False)
+                if "dnsEndpointConfig" in endpoints
+                else None
+            ),
+            "dns_allow_kubernetes_certs": (
+                dns.get("enableK8sCertsViaDns", False)
+                if "dnsEndpointConfig" in endpoints
+                else None
+            ),
+            "ip_endpoints_enabled": (
+                ip.get("enabled", False) if ip is not None else None
+            ),
+            "control_plane_public_access": (
+                (
+                    bool(dns.get("allowExternalTraffic"))
+                    or bool(
+                        (ip or {}).get("enabled")
+                        and (ip or {}).get("enablePublicEndpoint")
+                    )
+                )
+                if endpoints
+                else (
+                    not bool(
+                        (c.get("privateClusterConfig") or {}).get(
+                            "enablePrivateEndpoint"
+                        )
+                    )
+                )
+            ),
+            "public_ip_endpoint_enabled": (
+                (ip.get("enabled", False) and ip.get("enablePublicEndpoint", False))
+                if ip is not None
+                else None
+            ),
             "self_link": c["selfLink"],
             "name": c["name"],
             "created_at": c.get("createTime"),
@@ -211,3 +295,28 @@ def transform_gke_clusters(api_result: Dict[str, Any]) -> List[Dict[str, Any]]:
         }
         result.append(transformed)
     return result
+
+
+def transform_node_pools(api_result: Dict[str, Any]) -> list[dict[str, Any]]:
+    pools = []
+    for cluster in api_result.get("clusters", []):
+        ref = parse_cluster_ref(cluster.get("resource_name") or cluster["selfLink"])
+        for pool in cluster.get("nodePools", []):
+            config = pool.get("config") or {}
+            pools.append(
+                {
+                    "id": f"{ref.resource_name}/nodePools/{pool['name']}",
+                    "name": pool["name"],
+                    "cluster_id": cluster["selfLink"],
+                    "cluster_resource_name": ref.resource_name,
+                    "service_account": config.get("serviceAccount"),
+                    "oauth_scopes": config.get("oauthScopes"),
+                    "workload_metadata_mode": (
+                        config.get("workloadMetadataConfig") or {}
+                    ).get("mode"),
+                    "instance_group_urls": pool.get("instanceGroupUrls"),
+                    "status": pool.get("status"),
+                    "version": pool.get("version"),
+                }
+            )
+    return pools

--- a/cartography/intel/gcp/gke_utils.py
+++ b/cartography/intel/gcp/gke_utils.py
@@ -1,0 +1,33 @@
+import re
+from dataclasses import dataclass
+
+
+@dataclass(frozen=True)
+class GKEClusterRef:
+    project: str
+    location: str
+    name: str
+
+    @property
+    def resource_name(self) -> str:
+        return f"projects/{self.project}/locations/{self.location}/clusters/{self.name}"
+
+
+def parse_cluster_ref(value: str) -> GKEClusterRef:
+    """Normalize API resource names, selfLinks, and gcloud kubeconfig references."""
+    value = re.sub(r"^https://container\.googleapis\.com/v1(?:beta1)?/", "", value)
+    match = re.fullmatch(
+        r"projects/([a-zA-Z0-9-]+)/(?:locations|zones)/([a-z0-9-]+)/clusters/([a-z0-9-]+)",
+        value,
+    ) or re.fullmatch(r"gke_([a-zA-Z0-9-]+)_([a-z0-9-]+)_([a-z0-9-]+)", value)
+    if match is None:
+        raise ValueError("GKE cluster must identify its project, location, and name")
+    return GKEClusterRef(*match.groups())
+
+
+def instance_id_from_provider_id(value: str | None) -> str | None:
+    match = re.fullmatch(r"gce://([^/]+)/([^/]+)/([^/]+)", value or "")
+    if match is None:
+        return None
+    project, zone, name = match.groups()
+    return f"projects/{project}/zones/{zone}/instances/{name}"

--- a/cartography/intel/gcp/policy_bindings.py
+++ b/cartography/intel/gcp/policy_bindings.py
@@ -374,6 +374,7 @@ def transform_bindings(data: dict[str, Any]) -> list[dict[str, Any]]:
                 wif_pools: set[str] = set()
                 domains: set[str] = set()
                 is_public = False
+                has_gke_member = False
                 for member in members:
                     # GCP encodes the "anyone on the internet" principals as
                     # plain identifiers without a "type:" prefix. They never
@@ -393,6 +394,13 @@ def transform_bindings(data: dict[str, Any]) -> list[dict[str, Any]]:
                     if ":" not in member:
                         continue
                     member_type, identifier = member.split(":", 1)
+                    if (
+                        member_type == "serviceAccount"
+                        and ".svc.id.goog[" in identifier
+                        and identifier.endswith("]")
+                    ):
+                        has_gke_member = True
+                        continue
                     if member_type in ("user", "serviceAccount", "group"):
                         # Store only the email part
                         filtered_members.append(identifier)
@@ -409,6 +417,7 @@ def transform_bindings(data: dict[str, Any]) -> list[dict[str, Any]]:
                     and not is_public
                     and not wif_pools
                     and not domains
+                    and not has_gke_member
                 ):
                     continue
 
@@ -423,6 +432,9 @@ def transform_bindings(data: dict[str, Any]) -> list[dict[str, Any]]:
                 key = (resource, role, condition_expression)
 
                 if key in bindings:
+                    bindings[key]["raw_members"] = sorted(
+                        set(bindings[key]["raw_members"]) | set(members)
+                    )
                     existing_members = set(bindings[key]["members"])
                     existing_members.update(filtered_members)
                     bindings[key]["members"] = sorted(existing_members)
@@ -455,6 +467,7 @@ def transform_bindings(data: dict[str, Any]) -> list[dict[str, Any]]:
                         "resource": resource,
                         "resource_type": resource_type,
                         "members": sorted(filtered_members),
+                        "raw_members": sorted(set(members)),
                         "wif_pools": sorted(wif_pools),
                         "domains": sorted(domains),
                         "is_public": is_public,
@@ -538,9 +551,13 @@ def _claim_inherited_bindings_for_graph(
 def make_policy_binding_applies_to_matchlink(
     target_node_label: str,
     owner_label: str,
+    target_property: str = "id",
 ) -> GCPPolicyBindingAppliesToMatchLink:
     return GCPPolicyBindingAppliesToMatchLink(
         target_node_label=target_node_label,
+        target_node_matcher=make_target_node_matcher(
+            {target_property: PropertyRef("target_id")}
+        ),
         source_node_sub_resource=MatchLinkSubResource(
             target_node_label=owner_label,
             target_node_matcher=make_target_node_matcher(
@@ -550,6 +567,38 @@ def make_policy_binding_applies_to_matchlink(
             rel_label="RESOURCE",
         ),
     )
+
+
+def _load_applies_to_links(
+    session: neo4j.Session,
+    bindings: list[dict[str, Any]],
+    owner_label: str,
+    owner_id: str,
+    update_tag: int,
+) -> None:
+    for target_label, links in _group_applies_to_links(bindings).items():
+        # CAI SearchAllIamPolicies identifies service accounts by email, while
+        # other IAM responses use uniqueId. Both must resolve to the same node.
+        groups: dict[str, list[dict[str, str]]] = {}
+        for link in links:
+            key = (
+                "email"
+                if target_label == "GCPServiceAccount" and "@" in link["target_id"]
+                else "id"
+            )
+            groups.setdefault(key, []).append(link)
+        for key, rows in groups.items():
+            load_matchlinks(
+                session,
+                make_policy_binding_applies_to_matchlink(
+                    target_label, owner_label, key
+                ),
+                rows,
+                batch_size=GCP_POLICY_BINDINGS_GRAPH_BATCH_SIZE,
+                lastupdated=update_tag,
+                _sub_resource_label=owner_label,
+                _sub_resource_id=owner_id,
+            )
 
 
 @timeit
@@ -568,16 +617,9 @@ def load_bindings(
         PROJECT_ID=project_id,
     )
 
-    for target_label, links in _group_applies_to_links(bindings).items():
-        load_matchlinks(
-            neo4j_session,
-            make_policy_binding_applies_to_matchlink(target_label, "GCPProject"),
-            links,
-            batch_size=GCP_POLICY_BINDINGS_GRAPH_BATCH_SIZE,
-            lastupdated=update_tag,
-            _sub_resource_label="GCPProject",
-            _sub_resource_id=project_id,
-        )
+    _load_applies_to_links(
+        neo4j_session, bindings, "GCPProject", project_id, update_tag
+    )
 
 
 def _load_organization_bindings(
@@ -595,16 +637,9 @@ def _load_organization_bindings(
         ORG_RESOURCE_NAME=org_resource_name,
     )
 
-    for target_label, links in _group_applies_to_links(bindings).items():
-        load_matchlinks(
-            neo4j_session,
-            make_policy_binding_applies_to_matchlink(target_label, "GCPOrganization"),
-            links,
-            batch_size=GCP_POLICY_BINDINGS_GRAPH_BATCH_SIZE,
-            lastupdated=update_tag,
-            _sub_resource_label="GCPOrganization",
-            _sub_resource_id=org_resource_name,
-        )
+    _load_applies_to_links(
+        neo4j_session, bindings, "GCPOrganization", org_resource_name, update_tag
+    )
 
 
 def _load_folder_bindings(
@@ -622,16 +657,7 @@ def _load_folder_bindings(
         FOLDER_ID=folder_id,
     )
 
-    for target_label, links in _group_applies_to_links(bindings).items():
-        load_matchlinks(
-            neo4j_session,
-            make_policy_binding_applies_to_matchlink(target_label, "GCPFolder"),
-            links,
-            batch_size=GCP_POLICY_BINDINGS_GRAPH_BATCH_SIZE,
-            lastupdated=update_tag,
-            _sub_resource_label="GCPFolder",
-            _sub_resource_id=folder_id,
-        )
+    _load_applies_to_links(neo4j_session, bindings, "GCPFolder", folder_id, update_tag)
 
 
 @timeit

--- a/cartography/intel/gcp/workload_identity.py
+++ b/cartography/intel/gcp/workload_identity.py
@@ -96,6 +96,7 @@ def transform_pools(
         result.append(
             {
                 "id": pool_name,
+                "pool_id": pool_name.rsplit("/", 1)[-1],
                 "name": pool_name,
                 "displayName": pool.get("displayName"),
                 "description": pool.get("description"),

--- a/cartography/intel/kubernetes/__init__.py
+++ b/cartography/intel/kubernetes/__init__.py
@@ -1,4 +1,6 @@
 import logging
+from contextlib import contextmanager
+from typing import Iterator
 
 import boto3
 from neo4j import Session
@@ -6,9 +8,11 @@ from neo4j import Session
 from cartography.analysis.kubernetes.analysis import K8S_COMPUTE_ASSET_EXPOSURE_JOBS
 from cartography.analysis.kubernetes.analysis import K8S_LB_EXPOSURE_JOBS
 from cartography.config import Config
+from cartography.intel.kubernetes import gke_auth
 from cartography.intel.kubernetes.clusters import sync_kubernetes_cluster
 from cartography.intel.kubernetes.eks import sync as sync_eks
 from cartography.intel.kubernetes.gateway_api import sync_gateway_api
+from cartography.intel.kubernetes.gke import sync as sync_gke
 from cartography.intel.kubernetes.ingress import sync_ingress
 from cartography.intel.kubernetes.namespaces import sync_namespaces
 from cartography.intel.kubernetes.networkpolicies import sync_network_policies
@@ -19,6 +23,7 @@ from cartography.intel.kubernetes.secrets import sync_secrets
 from cartography.intel.kubernetes.services import sync_services
 from cartography.intel.kubernetes.storage import sync_storage
 from cartography.intel.kubernetes.util import get_k8s_clients
+from cartography.intel.kubernetes.util import K8sClient
 from cartography.intel.kubernetes.workloads import sync_workloads
 from cartography.util import run_typed_analysis_job
 from cartography.util import timeit
@@ -37,19 +42,43 @@ def get_region_from_arn(arn: str) -> str:
     return parts[3]
 
 
+@contextmanager
+def _gke_client(resource: str, config: Config) -> Iterator[K8sClient]:
+    credentials = gke_auth.get_credentials(config.gke_impersonate_service_account)
+    cluster = gke_auth.get_cluster(resource, credentials)
+    with gke_auth.connect(cluster, credentials, config.gke_endpoint) as client:
+        yield client
+
+
+def _clients(config: Config) -> Iterator[K8sClient]:
+    if config.k8s_kubeconfig:
+        for client in get_k8s_clients(config.k8s_kubeconfig):
+            if config.managed_kubernetes == "gke":
+                credentials = gke_auth.get_credentials(
+                    config.gke_impersonate_service_account
+                )
+                client.gke_cluster = gke_auth.get_cluster(
+                    client.external_id or "", credentials
+                )
+            yield client
+    for resource in getattr(config, "gke_clusters", None) or []:
+        with _gke_client(resource, config) as client:
+            yield client
+
+
 @timeit
 def start_k8s_ingestion(session: Session, config: Config) -> None:
     if not config.update_tag:
         logger.error("Cartography update tag not provided.")
         return
 
-    if not config.k8s_kubeconfig:
-        logger.error("Kubernetes kubeconfig not provided.")
+    if not config.k8s_kubeconfig and not getattr(config, "gke_clusters", None):
+        logger.error("Provide a Kubernetes kubeconfig or --gke-cluster.")
         return
 
     common_job_parameters = {"UPDATE_TAG": config.update_tag}
 
-    for client in get_k8s_clients(config.k8s_kubeconfig):
+    for client in _clients(config):
         logger.info(f"Syncing data for k8s cluster {client.name}...")
         try:
             cluster_info = sync_kubernetes_cluster(
@@ -121,8 +150,20 @@ def start_k8s_ingestion(session: Session, config: Config) -> None:
                 config.update_tag,
                 common_job_parameters,
             )
-            sync_gateway_api(session, client, config.update_tag, common_job_parameters)
+            gateway_complete = sync_gateway_api(
+                session, client, config.update_tag, common_job_parameters
+            )
             sync_ingress(session, client, config.update_tag, common_job_parameters)
+
+            gke_cluster = getattr(client, "gke_cluster", None)
+            if isinstance(gke_cluster, dict):
+                sync_gke(
+                    session,
+                    gke_cluster,
+                    cluster_info["id"],
+                    config.update_tag,
+                    gateway_complete=gateway_complete is not False,
+                )
 
             for job in K8S_COMPUTE_ASSET_EXPOSURE_JOBS:
                 run_typed_analysis_job(job, session, common_job_parameters)

--- a/cartography/intel/kubernetes/clusters.py
+++ b/cartography/intel/kubernetes/clusters.py
@@ -1,7 +1,10 @@
+import json
 import logging
 from typing import Any
 
 import neo4j
+from kubernetes.client import WellKnownApi
+from kubernetes.client.exceptions import ApiException
 from kubernetes.client.models import V1Namespace
 from kubernetes.client.models import VersionInfo
 
@@ -27,6 +30,9 @@ def get_kubernetes_cluster_version(client: K8sClient) -> VersionInfo:
 
 @timeit
 def get_kubernetes_cluster_tls_diagnostics(client: K8sClient) -> dict[str, Any]:
+    diagnostics = getattr(client, "tls_diagnostics", None)
+    if isinstance(diagnostics, dict):
+        return diagnostics
     return get_kubeconfig_tls_diagnostics(client.name, client.config_file)
 
 
@@ -49,6 +55,13 @@ def transform_kubernetes_cluster(
         "platform": version.platform,
     }
     cluster.update(tls_diagnostics)
+    metadata = getattr(client, "gke_cluster", None)
+    if isinstance(metadata, dict):
+        cluster["gke_resource_name"] = metadata["resource_name"]
+        cluster["gke_uid"] = metadata.get("id")
+        cluster["workload_pool"] = (metadata.get("workloadIdentityConfig") or {}).get(
+            "workloadPool"
+        )
 
     return [cluster]
 
@@ -79,6 +92,23 @@ def load_kubernetes_cluster(
 #     )
 
 
+def get_service_account_oidc(client: K8sClient) -> dict[str, str]:
+    # Read the raw JSON: some Kubernetes client versions coerce this endpoint's
+    # declared `str` response into a Python dict repr during deserialization.
+    response = WellKnownApi(
+        client.core.api_client
+    ).get_service_account_issuer_open_id_configuration(_preload_content=False)
+    try:
+        discovery = json.loads(response.data)
+    finally:
+        response.release_conn()
+    return {
+        key: value
+        for key, value in discovery.items()
+        if key in ("issuer", "jwks_uri") and isinstance(value, str)
+    }
+
+
 @timeit
 def sync_kubernetes_cluster(
     neo4j_session: neo4j.Session,
@@ -96,5 +126,16 @@ def sync_kubernetes_cluster(
         tls_diagnostics,
     )
 
+    if isinstance(getattr(client, "gke_cluster", None), dict):
+        try:
+            discovery = get_service_account_oidc(client)
+            cluster_info[0]["service_account_issuer"] = discovery.get("issuer")
+            cluster_info[0]["service_account_jwks_uri"] = discovery.get("jwks_uri")
+        except ApiException as err:
+            if err.status not in (401, 403, 404):
+                raise
+            logger.info(
+                "Service account OIDC discovery is unavailable for this Kubernetes reader"
+            )
     load_kubernetes_cluster(neo4j_session, cluster_info, update_tag)
     return cluster_info[0]

--- a/cartography/intel/kubernetes/gateway_api.py
+++ b/cartography/intel/kubernetes/gateway_api.py
@@ -126,6 +126,20 @@ def transform_gateways(gateways: list[dict[str, Any]]) -> list[dict[str, Any]]:
                 "namespace": namespace,
                 "qualified_name": get_qualified_resource_name(namespace, name),
                 "gateway_class_name": spec.get("gatewayClassName"),
+                "load_balancer_listeners": sorted(
+                    {
+                        f"{'UDP' if listener.get('protocol') == 'UDP' else 'TCP'}:{listener['port']}"
+                        for listener in spec.get("listeners", [])
+                        if listener.get("port")
+                    }
+                ),
+                "load_balancer_ips": sorted(
+                    {
+                        a["value"]
+                        for a in gateway.get("status", {}).get("addresses", [])
+                        if a.get("type", "IPAddress") == "IPAddress" and a.get("value")
+                    }
+                ),
                 "creation_timestamp": get_epoch(
                     parse_rfc3339(metadata.get("creationTimestamp"))
                 ),
@@ -284,7 +298,7 @@ def sync_gateway_api(
     client: K8sClient,
     update_tag: int,
     common_job_parameters: dict[str, Any],
-) -> None:
+) -> bool:
     try:
         raw_gateways = get_gateways(client)
         raw_routes = get_http_routes(client)
@@ -303,7 +317,7 @@ def sync_gateway_api(
                 client.name,
                 err.status,
             )
-            return
+            return False
         raise
 
     gateways = transform_gateways(raw_gateways)
@@ -328,3 +342,4 @@ def sync_gateway_api(
         cluster_name=client.name,
     )
     cleanup(neo4j_session, common_job_parameters)
+    return True

--- a/cartography/intel/kubernetes/gke.py
+++ b/cartography/intel/kubernetes/gke.py
@@ -1,0 +1,339 @@
+"""Join independently collected GKE, IAM, Compute, and Kubernetes inventory.
+
+These are configuration/evidence relationships, not an effective-permissions solver.
+No cloud calls are made per pod, service account, or IAM binding.
+"""
+
+import ipaddress
+from collections import defaultdict
+from typing import Any
+
+import neo4j
+
+from cartography.client.core.tx import load_matchlinks
+from cartography.client.core.tx import run_write_query
+from cartography.graph.job import GraphJob
+from cartography.intel.gcp.gke_utils import parse_cluster_ref
+from cartography.models.core.relationships import CartographyRelSchema
+from cartography.models.kubernetes.gke import GKEClusterMatchLink
+from cartography.models.kubernetes.gke import GKEGatewayLoadBalancerMatchLink
+from cartography.models.kubernetes.gke import GKEIngressLoadBalancerMatchLink
+from cartography.models.kubernetes.gke import GKENodePoolMatchLink
+from cartography.models.kubernetes.gke import GKEPoolMatchLink
+from cartography.models.kubernetes.gke import GKEServiceLoadBalancerMatchLink
+from cartography.models.kubernetes.gke import GKEUserMatchLink
+from cartography.models.kubernetes.gke import GKEWorkloadImpersonationMatchLink
+from cartography.models.kubernetes.gke import GKEWorkloadPolicyMatchLink
+
+
+def principal_members(sa: dict[str, Any], pool: str, cluster_resource: str) -> set[str]:
+    """Enumerate documented GKE member forms; no substring or pool-only matching."""
+    pool_id = pool.rsplit("/", 1)[-1]
+    principal = f"principal://iam.googleapis.com/{pool}"
+    principal_set = f"principalSet://iam.googleapis.com/{pool}"
+    namespace, name = sa["namespace"], sa["name"]
+    members = {
+        f"{principal}/subject/ns/{namespace}/sa/{name}",
+        f"{principal_set}/namespace/{namespace}",
+        f"{principal_set}/kubernetes.cluster/https://container.googleapis.com/v1/{cluster_resource}",
+        f"{principal_set}/*",
+        f"serviceAccount:{pool_id}[{namespace}/{name}]",
+    }
+    if sa.get("uid"):
+        members.add(f"{principal}/kubernetes.serviceaccount.uid/{sa['uid']}")
+    return members
+
+
+def match_workload_policies(
+    service_accounts: list[dict[str, Any]],
+    bindings: list[dict[str, Any]],
+    pool: str,
+    cluster_resource: str,
+) -> tuple[list[dict[str, Any]], list[dict[str, Any]]]:
+    """Index exact selectors once, avoiding a KSA x all-project-bindings scan."""
+    by_member: dict[str, list[dict[str, Any]]] = defaultdict(list)
+    for binding in bindings:
+        for member in binding.get("raw_members") or []:
+            by_member[member].append(binding)
+    grants, impersonations = [], []
+    for sa in service_accounts:
+        matched: dict[str, tuple[dict[str, Any], set[str]]] = {}
+        for member in principal_members(sa, pool, cluster_resource):
+            for binding in by_member.get(member, []):
+                matched.setdefault(binding["id"], (binding, set()))[1].add(member)
+        for binding, members in matched.values():
+            row = {
+                "source_id": sa["id"],
+                "target_id": binding["id"],
+                "matched_members": sorted(members),
+                "policy_lastupdated": binding.get("lastupdated"),
+            }
+            grants.append(row)
+            # Use the observed APPLIES_TO GSA email, not a guessed resource-name suffix.
+            email = sa.get("gcp_service_account")
+            if (
+                email
+                and email in (binding.get("service_account_emails") or [])
+                and binding.get("role") == "roles/iam.workloadIdentityUser"
+                and binding.get("has_condition") is False
+            ):
+                impersonations.append({**row, "target_id": email})
+    return grants, impersonations
+
+
+def _network_path(value: str | None) -> str | None:
+    if not value:
+        return None
+    return value.removeprefix("https://www.googleapis.com/compute/v1/").removeprefix(
+        "https://compute.googleapis.com/compute/v1/"
+    )
+
+
+def _listener_matches(resource: dict[str, Any], rule: dict[str, Any]) -> bool:
+    listeners = resource.get("load_balancer_listeners")
+    if not listeners:
+        return True
+    for listener in listeners:
+        protocol, port = listener.split(":", 1)
+        if rule.get("ip_protocol") and rule["ip_protocol"] not in (
+            protocol,
+            "L3_DEFAULT",
+        ):
+            continue
+        if rule.get("ports"):
+            if port in rule["ports"]:
+                return True
+        elif rule.get("port_range"):
+            bounds = rule["port_range"].split("-")
+            try:
+                if int(bounds[0]) <= int(port) <= int(bounds[-1]):
+                    return True
+            except ValueError:
+                continue
+        else:
+            # Compute allPorts forwarding rules omit both ports and portRange.
+            return True
+    return False
+
+
+def match_load_balancers(
+    resources: list[dict[str, Any]],
+    rules: list[dict[str, Any]],
+    project: str,
+    network: str | None,
+) -> list[dict[str, str]]:
+    by_address: dict[str, list[dict[str, Any]]] = defaultdict(list)
+    for rule in rules:
+        if rule.get("project_id") != project:
+            continue
+        if rule.get("lb_type") == "vpn":
+            continue
+        scheme = rule.get("load_balancing_scheme") or ""
+        # Unknown forwarding rule types (e.g. VPN) must not become load balancers.
+        if scheme not in {
+            "EXTERNAL",
+            "EXTERNAL_MANAGED",
+            "INTERNAL",
+            "INTERNAL_MANAGED",
+            "INTERNAL_SELF_MANAGED",
+        }:
+            continue
+        if scheme.startswith("INTERNAL") and (
+            not network or _network_path(rule.get("network")) != _network_path(network)
+        ):
+            continue
+        try:
+            address = str(ipaddress.ip_address(rule.get("ip_address", "")))
+        except ValueError:
+            continue
+        by_address[address].append(rule)
+    matches: set[tuple[str, str]] = set()
+    for resource in resources:
+        for address in resource.get("load_balancer_ips") or []:
+            try:
+                canonical = str(ipaddress.ip_address(address))
+            except ValueError:
+                continue
+            matches.update(
+                (resource["id"], rule["id"])
+                for rule in by_address.get(canonical, [])
+                if _listener_matches(resource, rule)
+            )
+    return [
+        {"source_id": source, "target_id": target} for source, target in sorted(matches)
+    ]
+
+
+def _load_links(
+    session: neo4j.Session,
+    schema: CartographyRelSchema,
+    rows: list[dict[str, Any]],
+    scope: str,
+    scope_id: str,
+    tag: int,
+) -> None:
+    load_matchlinks(
+        session,
+        schema,
+        rows,
+        lastupdated=tag,
+        _sub_resource_label=scope,
+        _sub_resource_id=scope_id,
+    )
+    GraphJob.from_matchlink(schema, scope, scope_id, tag).run(session)
+
+
+def sync(
+    session: neo4j.Session,
+    cluster: dict[str, Any],
+    cluster_id: str,
+    update_tag: int,
+    gateway_complete: bool = True,
+) -> None:
+    ref = parse_cluster_ref(cluster["resource_name"])
+    cloud = session.run(
+        "MATCH (g:GKECluster {resource_name: $name}) RETURN g.id AS id, g.network_uri AS network",
+        name=ref.resource_name,
+    ).single()
+    if cloud:
+        _load_links(
+            session,
+            GKEClusterMatchLink(),
+            [{"source_id": cloud["id"], "target_id": cluster_id}],
+            "GKECluster",
+            cloud["id"],
+            update_tag,
+        )
+        # One cloud resource has one current kube-system UID, including recreation within a sync tag.
+        run_write_query(
+            session,
+            "MATCH (g:GKECluster {id: $cloud_id})-[r:MAPS_TO]->(k:KubernetesCluster) WHERE k.id <> $cluster_id DELETE r",
+            cloud_id=cloud["id"],
+            cluster_id=cluster_id,
+        )
+    scope = "KubernetesCluster"
+    nodes = session.run(
+        "MATCH (:KubernetesCluster {id: $id})-[:RESOURCE]->(n:KubernetesNode) WHERE n.lastupdated = $tag RETURN n.id AS source_id, n.gke_node_pool AS pool",
+        id=cluster_id,
+        tag=update_tag,
+    ).data()
+    _load_links(
+        session,
+        GKENodePoolMatchLink(),
+        [
+            {
+                "source_id": n["source_id"],
+                "target_id": f"{ref.resource_name}/nodePools/{n['pool']}",
+            }
+            for n in nodes
+            if n["pool"]
+        ],
+        scope,
+        cluster_id,
+        update_tag,
+    )
+    pool_name = (cluster.get("workloadIdentityConfig") or {}).get("workloadPool")
+    pool = (
+        session.run(
+            "MATCH (p:GCPWorkloadIdentityPool {project_id: $project, pool_id: $pool}) RETURN p.id AS id",
+            project=ref.project,
+            pool=pool_name,
+        ).single()
+        if pool_name
+        else None
+    )
+    if cloud:
+        _load_links(
+            session,
+            GKEPoolMatchLink(),
+            [{"source_id": cloud["id"], "target_id": pool["id"]}] if pool else [],
+            "GKECluster",
+            cloud["id"],
+            update_tag,
+        )
+    # Missing cloud inventory is unknown, not an empty IAM policy snapshot.
+    if pool:
+        accounts = session.run(
+            "MATCH (:KubernetesCluster {id: $id})-[:RESOURCE]->(s:KubernetesServiceAccount) WHERE s.lastupdated = $tag RETURN properties(s) AS sa",
+            id=cluster_id,
+            tag=update_tag,
+        )
+        sas = [r["sa"] for r in accounts]
+        bindings = session.run(
+            "MATCH (b:GCPPolicyBinding) WHERE $pool IN b.wif_pools OR any(m IN b.raw_members WHERE m STARTS WITH $legacy) OPTIONAL MATCH (b)-[:APPLIES_TO]->(g:GCPServiceAccount) RETURN properties(b) AS binding, collect(g.email) AS emails",
+            pool=pool["id"],
+            legacy=f"serviceAccount:{pool_name}[",
+        )
+        policies = [
+            {**r["binding"], "service_account_emails": r["emails"]} for r in bindings
+        ]
+        grants, impersonations = match_workload_policies(
+            sas, policies, pool["id"], ref.resource_name
+        )
+        _load_links(
+            session, GKEWorkloadPolicyMatchLink(), grants, scope, cluster_id, update_tag
+        )
+        _load_links(
+            session,
+            GKEWorkloadImpersonationMatchLink(),
+            impersonations,
+            scope,
+            cluster_id,
+            update_tag,
+        )
+        # DEPRECATED: remove pre-v1.0.0 annotation-only edges after valid edges have been merged.
+        run_write_query(
+            session,
+            "MATCH (:KubernetesCluster {id: $id})-[:RESOURCE]->(:KubernetesServiceAccount)-[r:WORKLOAD_IDENTITY_BINDING]->(:GCPServiceAccount) WHERE r._sub_resource_id IS NULL DELETE r",
+            id=cluster_id,
+        )
+    elif not pool_name:
+        _load_links(
+            session, GKEWorkloadPolicyMatchLink(), [], scope, cluster_id, update_tag
+        )
+        _load_links(
+            session,
+            GKEWorkloadImpersonationMatchLink(),
+            [],
+            scope,
+            cluster_id,
+            update_tag,
+        )
+    users = session.run(
+        "MATCH (:KubernetesCluster {id: $id})-[:RESOURCE]->(u:KubernetesUser) WHERE u.lastupdated = $tag RETURN u.name AS source_id, u.id AS target_id",
+        id=cluster_id,
+        tag=update_tag,
+    ).data()
+    _load_links(session, GKEUserMatchLink(), users, scope, cluster_id, update_tag)
+    # Shared VPC network lives in the host project; forwarding rules remain scoped to the service project.
+    network = (cluster.get("networkConfig") or {}).get("network") or (
+        cloud["network"] if cloud else None
+    )
+    rules = [
+        r["rule"]
+        for r in session.run(
+            "MATCH (r:GCPForwardingRule {project_id: $project}) RETURN properties(r) AS rule",
+            project=ref.project,
+        )
+    ]
+    schemas = [GKEServiceLoadBalancerMatchLink(), GKEIngressLoadBalancerMatchLink()]
+    if gateway_complete:
+        schemas.append(GKEGatewayLoadBalancerMatchLink())
+    for schema in schemas:
+        # Labels come exclusively from the static schemas above.
+        resources = [
+            r["resource"]
+            for r in session.run(
+                f"MATCH (:KubernetesCluster {{id: $id}})-[:RESOURCE]->(s:{schema.source_node_label}) WHERE s.lastupdated = $tag RETURN properties(s) AS resource",
+                id=cluster_id,
+                tag=update_tag,
+            )
+        ]
+        _load_links(
+            session,
+            schema,
+            match_load_balancers(resources, rules, ref.project, network),
+            scope,
+            cluster_id,
+            update_tag,
+        )

--- a/cartography/intel/kubernetes/gke_auth.py
+++ b/cartography/intel/kubernetes/gke_auth.py
@@ -1,0 +1,133 @@
+import base64
+import ipaddress
+import logging
+import tempfile
+from contextlib import contextmanager
+from pathlib import Path
+from threading import Lock
+from typing import Any
+from typing import Iterator
+
+import google.auth
+from google.auth import impersonated_credentials
+from google.auth.credentials import Credentials
+from google.auth.transport.requests import Request
+from googleapiclient.discovery import build
+from kubernetes.client import ApiClient
+from kubernetes.client import Configuration
+from requests.utils import DEFAULT_CA_BUNDLE_PATH
+
+from cartography.intel.gcp.gke_utils import parse_cluster_ref
+from cartography.intel.gcp.util import gcp_api_execute_with_retry
+from cartography.intel.kubernetes.util import K8sClient
+
+logger = logging.getLogger(__name__)
+SCOPES = (
+    "https://www.googleapis.com/auth/cloud-platform",
+    "https://www.googleapis.com/auth/userinfo.email",
+)
+
+
+def get_credentials(service_account: str | None = None) -> Credentials:
+    credentials, _ = google.auth.default(scopes=SCOPES)
+    if service_account:
+        credentials = impersonated_credentials.Credentials(
+            source_credentials=credentials,
+            target_principal=service_account,
+            target_scopes=SCOPES,
+        )
+    return credentials
+
+
+def get_cluster(resource_name: str, credentials: Credentials) -> dict[str, Any]:
+    reference = parse_cluster_ref(resource_name)
+    with build(
+        "container", "v1", credentials=credentials, cache_discovery=False
+    ) as api:
+        cluster = gcp_api_execute_with_retry(
+            api.projects().locations().clusters().get(name=reference.resource_name)
+        )
+    # Carry the requested project ID even when Google's selfLink uses a project number.
+    cluster["resource_name"] = reference.resource_name
+    return cluster
+
+
+def select_endpoint(cluster: dict[str, Any], endpoint: str) -> tuple[str, bool]:
+    endpoints = cluster.get("controlPlaneEndpointsConfig") or {}
+    if endpoint == "dns":
+        dns = endpoints.get("dnsEndpointConfig") or {}
+        hostname = dns.get("endpoint", "")
+        if not dns.get("allowExternalTraffic") or not hostname.endswith(".gke.goog"):
+            raise ValueError("GKE DNS access is not enabled for this cluster")
+        if any(c in hostname for c in "/:@?#"):
+            raise ValueError("Invalid GKE DNS endpoint")
+        return f"https://{hostname}", True
+    if endpoint not in ("private", "public"):
+        raise ValueError("GKE endpoint must be dns, private, or public")
+    ip_config = endpoints.get("ipEndpointsConfig")
+    legacy = cluster.get("privateClusterConfig") or {}
+    if ip_config is not None:
+        if not ip_config.get("enabled"):
+            raise ValueError("GKE IP endpoint access is disabled")
+        if endpoint == "public" and not ip_config.get("enablePublicEndpoint"):
+            raise ValueError("GKE public IP endpoint access is disabled")
+        address = ip_config.get(f"{endpoint}Endpoint")
+    else:
+        if endpoint == "public" and legacy.get("enablePrivateEndpoint"):
+            raise ValueError("GKE public IP endpoint access is disabled")
+        address = legacy.get(f"{endpoint}Endpoint")
+        if endpoint == "public" and not address:
+            address = cluster.get("endpoint")
+    if not address:
+        raise ValueError(f"GKE {endpoint} endpoint is unavailable")
+    parsed = ipaddress.ip_address(address)
+    host = f"[{parsed}]" if parsed.version == 6 else str(parsed)
+    return f"https://{host}", False
+
+
+@contextmanager
+def connect(
+    cluster: dict[str, Any], credentials: Credentials, endpoint: str = "dns"
+) -> Iterator[K8sClient]:
+    """Create one isolated, refreshable Kubernetes client without a kubeconfig."""
+    ref = parse_cluster_ref(cluster["resource_name"])
+    host, public_ca = select_endpoint(cluster, endpoint)
+    configuration = Configuration()
+    configuration.host = host
+    configuration.verify_ssl = True
+    lock = Lock()
+
+    def refresh(config: Configuration) -> None:
+        with lock:
+            if not credentials.valid:
+                credentials.refresh(Request())
+            config.api_key["authorization"] = f"Bearer {credentials.token}"
+
+    configuration.refresh_api_key_hook = refresh
+    refresh(configuration)
+    with tempfile.TemporaryDirectory(prefix="cartography-gke-") as directory:
+        if public_ca:
+            configuration.ssl_ca_cert = DEFAULT_CA_BUNDLE_PATH
+        else:
+            ca_file = Path(directory) / "ca.crt"
+            ca_file.write_bytes(
+                base64.b64decode(
+                    cluster["masterAuth"]["clusterCaCertificate"], validate=True
+                )
+            )
+            configuration.ssl_ca_cert = str(ca_file)
+        with ApiClient(configuration) as api_client:
+            yield K8sClient(
+                name=f"gke_{ref.project}_{ref.location}_{ref.name}",
+                config_file="",
+                external_id=ref.resource_name,
+                api_client=api_client,
+                gke_cluster=cluster,
+                tls_diagnostics={
+                    "api_server_url": host,
+                    "kubeconfig_insecure_skip_tls_verify": False,
+                    "kubeconfig_tls_configuration_status": (
+                        "public_ca" if public_ca else "valid_config"
+                    ),
+                },
+            )

--- a/cartography/intel/kubernetes/ingress.py
+++ b/cartography/intel/kubernetes/ingress.py
@@ -21,7 +21,9 @@ logger = logging.getLogger(__name__)
 
 
 def get_ingress(client: K8sClient) -> list[V1Ingress]:
-    items = k8s_paginate(client.networking.list_ingress_for_all_namespaces)
+    items = k8s_paginate(
+        client.networking.list_ingress_for_all_namespaces, raise_on_error=True
+    )
     return items
 
 
@@ -125,7 +127,11 @@ def transform_ingresses(ingress: list[V1Ingress]) -> list[dict[str, Any]]:
 
         # extract load balancer DNS names from status for cloud LB matching
         load_balancer_dns_names: list[str] = []
+        load_balancer_ips: list[str] = []
         if item.status and item.status.load_balancer:
+            load_balancer_ips = sorted(
+                {i.ip for i in item.status.load_balancer.ingress or [] if i.ip}
+            )
             load_balancer_dns_names = _extract_load_balancer_dns_names(
                 item.status.load_balancer.ingress
             )
@@ -151,6 +157,7 @@ def transform_ingresses(ingress: list[V1Ingress]) -> list[dict[str, Any]]:
                 "target_services": list(backend_services),
                 "ingress_group_name": ingress_group_name,
                 "load_balancer_dns_names": load_balancer_dns_names,
+                "load_balancer_ips": load_balancer_ips,
             }
         )
     return transformed_ingresses

--- a/cartography/intel/kubernetes/nodes.py
+++ b/cartography/intel/kubernetes/nodes.py
@@ -8,6 +8,7 @@ from kubernetes.client.models import V1Node
 from cartography.client.core.tx import load
 from cartography.graph.job import GraphJob
 from cartography.intel.container_arch import normalize_architecture
+from cartography.intel.gcp.gke_utils import instance_id_from_provider_id
 from cartography.intel.kubernetes.util import format_resource_quantities
 from cartography.intel.kubernetes.util import get_gpu_quantity
 from cartography.intel.kubernetes.util import k8s_paginate
@@ -20,7 +21,7 @@ logger = logging.getLogger(__name__)
 
 @timeit
 def get_nodes(client: K8sClient) -> list[V1Node]:
-    return k8s_paginate(client.core.list_node)
+    return k8s_paginate(client.core.list_node, raise_on_error=True)
 
 
 def _ec2_instance_id_from_provider_id(provider_id: str | None) -> str | None:
@@ -49,6 +50,8 @@ def transform_nodes(nodes: list[V1Node], cluster_name: str) -> list[dict[str, An
                 "name": node.metadata.name,
                 "provider_id": provider_id,
                 "instance_id": _ec2_instance_id_from_provider_id(provider_id),
+                "gcp_instance_id": instance_id_from_provider_id(provider_id),
+                "gke_node_pool": labels.get("cloud.google.com/gke-nodepool"),
                 "labels": json.dumps(labels, sort_keys=True),
                 "capacity": format_resource_quantities(capacity),
                 "allocatable": format_resource_quantities(allocatable),

--- a/cartography/intel/kubernetes/rbac.py
+++ b/cartography/intel/kubernetes/rbac.py
@@ -1,3 +1,4 @@
+import json
 import logging
 from itertools import chain
 from typing import Any
@@ -12,6 +13,7 @@ from kubernetes.client import V1RoleBinding
 from kubernetes.client import V1ServiceAccount
 
 from cartography.client.core.tx import load
+from cartography.client.core.tx import run_write_query
 from cartography.graph.job import GraphJob
 from cartography.intel.kubernetes.util import get_epoch
 from cartography.intel.kubernetes.util import k8s_paginate
@@ -37,31 +39,37 @@ GKE_WORKLOAD_IDENTITY_ANNOTATION = "iam.gke.io/gcp-service-account"
 @timeit
 def get_service_accounts(k8s_client: K8sClient) -> List[V1ServiceAccount]:
 
-    return k8s_paginate(k8s_client.core.list_service_account_for_all_namespaces)
+    return k8s_paginate(
+        k8s_client.core.list_service_account_for_all_namespaces, raise_on_error=True
+    )
 
 
 @timeit
 def get_roles(k8s_client: K8sClient) -> List[V1Role]:
 
-    return k8s_paginate(k8s_client.rbac.list_role_for_all_namespaces)
+    return k8s_paginate(
+        k8s_client.rbac.list_role_for_all_namespaces, raise_on_error=True
+    )
 
 
 @timeit
 def get_role_bindings(k8s_client: K8sClient) -> List[V1RoleBinding]:
 
-    return k8s_paginate(k8s_client.rbac.list_role_binding_for_all_namespaces)
+    return k8s_paginate(
+        k8s_client.rbac.list_role_binding_for_all_namespaces, raise_on_error=True
+    )
 
 
 @timeit
 def get_cluster_roles(k8s_client: K8sClient) -> List[V1ClusterRole]:
 
-    return k8s_paginate(k8s_client.rbac.list_cluster_role)
+    return k8s_paginate(k8s_client.rbac.list_cluster_role, raise_on_error=True)
 
 
 @timeit
 def get_cluster_role_bindings(k8s_client: K8sClient) -> List[V1ClusterRoleBinding]:
 
-    return k8s_paginate(k8s_client.rbac.list_cluster_role_binding)
+    return k8s_paginate(k8s_client.rbac.list_cluster_role_binding, raise_on_error=True)
 
 
 def transform_service_accounts(
@@ -125,6 +133,9 @@ def transform_roles(roles: List[V1Role], cluster_name: str) -> List[Dict[str, An
                 "uid": role.metadata.uid,
                 "creation_timestamp": get_epoch(role.metadata.creation_timestamp),
                 "resource_version": role.metadata.resource_version,
+                "rules": json.dumps(
+                    [r.to_dict() for r in role.rules or []], sort_keys=True
+                ),
                 "api_groups": sorted(
                     all_api_groups
                 ),  # sorts to keep consistent ordering and converts to list to appease neo4j
@@ -219,6 +230,9 @@ def transform_cluster_roles(
                     cluster_role.metadata.creation_timestamp
                 ),
                 "resource_version": cluster_role.metadata.resource_version,
+                "rules": json.dumps(
+                    [r.to_dict() for r in cluster_role.rules or []], sort_keys=True
+                ),
                 "api_groups": sorted(
                     all_api_groups
                 ),  # sorts to keep consistent ordering and converts to list to appease neo4j
@@ -599,4 +613,11 @@ def sync_kubernetes_rbac(
         cluster_name=cluster_name,
     )
 
+    # DEPRECATED: pre-v1.0.0 annotation-only edges did not prove IAM authorization.
+    # Annotation evidence is loaded first; verified GKE edges have their own scope marker.
+    run_write_query(
+        session,
+        "MATCH (:KubernetesCluster {id: $id})-[:RESOURCE]->(:KubernetesServiceAccount)-[r:WORKLOAD_IDENTITY_BINDING]->(:GCPServiceAccount) WHERE r._sub_resource_id IS NULL DELETE r",
+        id=cluster_id,
+    )
     cleanup(session, common_job_parameters)

--- a/cartography/intel/kubernetes/services.py
+++ b/cartography/intel/kubernetes/services.py
@@ -21,7 +21,9 @@ logger = logging.getLogger(__name__)
 
 @timeit
 def get_services(client: K8sClient) -> list[V1Service]:
-    items = k8s_paginate(client.core.list_service_for_all_namespaces)
+    items = k8s_paginate(
+        client.core.list_service_for_all_namespaces, raise_on_error=True
+    )
     return items
 
 
@@ -102,11 +104,21 @@ def transform_services(
             "selector": _format_service_selector(service.spec.selector),
             "cluster_ip": service.spec.cluster_ip,
             "load_balancer_ip": service.spec.load_balancer_ip,
+            "load_balancer_ips": [],
+            "load_balancer_listeners": sorted(
+                {
+                    f"{port.protocol or 'TCP'}:{port.port}"
+                    for port in service.spec.ports or []
+                }
+            ),
         }
 
         # TODO: instead of storing a json string, we should probably create seperate nodes for each ingress
         if service.spec.type == "LoadBalancer":
-            if service.status.load_balancer:
+            if service.status and service.status.load_balancer:
+                item["load_balancer_ips"] = sorted(
+                    {i.ip for i in service.status.load_balancer.ingress or [] if i.ip}
+                )
                 item["load_balancer_ingress"] = _format_load_balancer_ingress(
                     service.status.load_balancer.ingress
                 )

--- a/cartography/intel/kubernetes/util.py
+++ b/cartography/intel/kubernetes/util.py
@@ -184,18 +184,23 @@ class K8sClient:
         name: str,
         config_file: str,
         external_id: str | None = None,
+        api_client: ApiClient | None = None,
+        gke_cluster: dict[str, Any] | None = None,
+        tls_diagnostics: dict[str, Any] | None = None,
     ) -> None:
         self.name = name
         self.config_file = config_file
         self.external_id = external_id
-        self.core = K8CoreApiClient(self.name, self.config_file)
-        self.networking = K8NetworkingApiClient(self.name, self.config_file)
-        self.version = K8VersionApiClient(self.name, self.config_file)
-        self.rbac = K8RbacApiClient(self.name, self.config_file)
-        self.custom = K8CustomObjectsApiClient(self.name, self.config_file)
-        self.apps = K8AppsApiClient(self.name, self.config_file)
-        self.batch = K8BatchApiClient(self.name, self.config_file)
-        self.storage = K8StorageApiClient(self.name, self.config_file)
+        self.gke_cluster = gke_cluster
+        self.tls_diagnostics = tls_diagnostics
+        self.core = K8CoreApiClient(self.name, self.config_file, api_client)
+        self.networking = K8NetworkingApiClient(self.name, self.config_file, api_client)
+        self.version = K8VersionApiClient(self.name, self.config_file, api_client)
+        self.rbac = K8RbacApiClient(self.name, self.config_file, api_client)
+        self.custom = K8CustomObjectsApiClient(self.name, self.config_file, api_client)
+        self.apps = K8AppsApiClient(self.name, self.config_file, api_client)
+        self.batch = K8BatchApiClient(self.name, self.config_file, api_client)
+        self.storage = K8StorageApiClient(self.name, self.config_file, api_client)
 
 
 def get_k8s_clients(kubeconfig: str) -> list[K8sClient]:

--- a/cartography/models/gcp/gke.py
+++ b/cartography/models/gcp/gke.py
@@ -8,6 +8,7 @@ from cartography.models.core.relationships import CartographyRelProperties
 from cartography.models.core.relationships import CartographyRelSchema
 from cartography.models.core.relationships import LinkDirection
 from cartography.models.core.relationships import make_target_node_matcher
+from cartography.models.core.relationships import OtherRelationships
 from cartography.models.core.relationships import TargetNodeMatcher
 from cartography.models.ontology.labels import COMPUTE_CLUSTER
 
@@ -18,6 +19,59 @@ class GCPGKEClusterNodeProperties(CartographyNodeProperties):
         "id", extra_index=True, description="Stable identifier for this resource."
     )
     lastupdated: PropertyRef = PropertyRef("lastupdated", set_in_kwargs=True)
+    resource_name: PropertyRef = PropertyRef(
+        "resource_name",
+        extra_index=True,
+        description="Normalized projects/project/locations/location/clusters/name reference.",
+    )
+    project_id: PropertyRef = PropertyRef(
+        "project_id", description="Project identifier in the GKE resource reference."
+    )
+    gke_uid: PropertyRef = PropertyRef(
+        "gke_uid",
+        description="Immutable Google-generated cluster ID; distinct from the Kubernetes namespace UID.",
+    )
+    autopilot_enabled: PropertyRef = PropertyRef(
+        "autopilot_enabled", description="Whether this is an Autopilot cluster."
+    )
+    workload_pool: PropertyRef = PropertyRef(
+        "workload_pool",
+        description="GKE-managed workload pool, typically PROJECT_ID.svc.id.goog.",
+    )
+    network_uri: PropertyRef = PropertyRef(
+        "network_uri",
+        description="Full project-scoped network resource path, including the host project for Shared VPC.",
+    )
+    datapath_provider: PropertyRef = PropertyRef(
+        "datapath_provider",
+        description="Dataplane implementation, including ADVANCED_DATAPATH for Dataplane V2.",
+    )
+    dns_endpoint: PropertyRef = PropertyRef(
+        "dns_endpoint", description="Google-managed DNS API endpoint."
+    )
+    dns_endpoint_enabled: PropertyRef = PropertyRef(
+        "dns_endpoint_enabled",
+        description="Whether user traffic is enabled on the DNS endpoint.",
+    )
+    dns_allow_kubernetes_tokens: PropertyRef = PropertyRef(
+        "dns_allow_kubernetes_tokens",
+        description="Whether Kubernetes ServiceAccount tokens are accepted through the DNS endpoint.",
+    )
+    dns_allow_kubernetes_certs: PropertyRef = PropertyRef(
+        "dns_allow_kubernetes_certs",
+        description="Whether Kubernetes client certificates are accepted through the DNS endpoint.",
+    )
+    ip_endpoints_enabled: PropertyRef = PropertyRef(
+        "ip_endpoints_enabled", description="Whether direct IP access is enabled."
+    )
+    control_plane_public_access: PropertyRef = PropertyRef(
+        "control_plane_public_access",
+        description="Whether an authenticated DNS endpoint or public IP endpoint is enabled for clients. IAM and network controls still apply.",
+    )
+    public_ip_endpoint_enabled: PropertyRef = PropertyRef(
+        "public_ip_endpoint_enabled",
+        description="Whether direct public IP access is enabled; an allocated IP alone does not imply access.",
+    )
     name: PropertyRef = PropertyRef("name", description="The name of the cluster.")
     self_link: PropertyRef = PropertyRef(
         "self_link", description="Canonical Google Cloud API URL for this resource."
@@ -76,7 +130,7 @@ class GCPGKEClusterNodeProperties(CartographyNodeProperties):
     )
     network_policy: PropertyRef = PropertyRef(
         "network_policy",
-        description="Set to `True` if a network policy provider has been enabled.",
+        description="Network policy provider when enabled, including DATAPLANE_V2; otherwise false. This records the engine, not policy coverage.",
     )
     master_authorized_networks: PropertyRef = PropertyRef(
         "master_authorized_networks",
@@ -148,6 +202,24 @@ class GCPGKEClusterToProjectRel(CartographyRelSchema):
 
 
 @dataclass(frozen=True)
+class GKEClusterToWorkloadIdentityPoolRel(CartographyRelSchema):
+    """Links a cluster to its Google-managed workload identity pool."""
+
+    target_node_label: str = "GCPWorkloadIdentityPool"
+    target_node_matcher: TargetNodeMatcher = make_target_node_matcher(
+        {
+            "pool_id": PropertyRef("workload_pool"),
+            "project_id": PropertyRef("project_id"),
+        }
+    )
+    direction: LinkDirection = LinkDirection.OUTWARD
+    rel_label: str = "USES_WORKLOAD_IDENTITY_POOL"
+    properties: GCPGKEClusterToProjectRelProperties = (
+        GCPGKEClusterToProjectRelProperties()
+    )
+
+
+@dataclass(frozen=True)
 class GCPGKEClusterSchema(CartographyNodeSchema):
     """Representation of a GCP [GKE Cluster](https://cloud.google.com/kubernetes-engine/docs/reference/rest/v1/)."""
 
@@ -155,3 +227,87 @@ class GCPGKEClusterSchema(CartographyNodeSchema):
     extra_node_labels: ExtraNodeLabels = ExtraNodeLabels([COMPUTE_CLUSTER])
     properties: GCPGKEClusterNodeProperties = GCPGKEClusterNodeProperties()
     sub_resource_relationship: GCPGKEClusterToProjectRel = GCPGKEClusterToProjectRel()
+    other_relationships: OtherRelationships = OtherRelationships(
+        [GKEClusterToWorkloadIdentityPoolRel()]
+    )
+
+
+@dataclass(frozen=True)
+class GKENodePoolNodeProperties(CartographyNodeProperties):
+    id: PropertyRef = PropertyRef(
+        "id",
+        description="Canonical GKE cluster resource name followed by /nodePools/NAME.",
+    )
+    lastupdated: PropertyRef = PropertyRef("lastupdated", set_in_kwargs=True)
+    name: PropertyRef = PropertyRef(
+        "name", description="Node pool name within its cluster."
+    )
+    cluster_resource_name: PropertyRef = PropertyRef(
+        "cluster_resource_name", description="Normalized owning cluster reference."
+    )
+    service_account: PropertyRef = PropertyRef(
+        "service_account",
+        description="Configured node Google service account; the API may return default.",
+    )
+    oauth_scopes: PropertyRef = PropertyRef(
+        "oauth_scopes", description="OAuth scopes available to node credentials."
+    )
+    workload_metadata_mode: PropertyRef = PropertyRef(
+        "workload_metadata_mode",
+        description="GKE_METADATA uses workload identity; GCE_METADATA exposes Compute metadata.",
+    )
+    instance_group_urls: PropertyRef = PropertyRef(
+        "instance_group_urls",
+        description="Managed instance group URLs reported by GKE; Compute visibility varies by cluster mode.",
+    )
+    status: PropertyRef = PropertyRef(
+        "status", description="Provider-reported node pool status."
+    )
+    version: PropertyRef = PropertyRef(
+        "version", description="Node pool Kubernetes version."
+    )
+
+
+@dataclass(frozen=True)
+class GKENodePoolToClusterRel(CartographyRelSchema):
+    """Links a GKE cluster to its node pools."""
+
+    target_node_label: str = "GKECluster"
+    target_node_matcher: TargetNodeMatcher = make_target_node_matcher(
+        {"id": PropertyRef("cluster_id")}
+    )
+    direction: LinkDirection = LinkDirection.INWARD
+    rel_label: str = "HAS_NODE_POOL"
+    properties: GCPGKEClusterToProjectRelProperties = (
+        GCPGKEClusterToProjectRelProperties()
+    )
+
+
+@dataclass(frozen=True)
+class GKENodePoolToServiceAccountRel(CartographyRelSchema):
+    """The Google service account used by the pool's nodes, including image pulls."""
+
+    target_node_label: str = "GCPServiceAccount"
+    target_node_matcher: TargetNodeMatcher = make_target_node_matcher(
+        {"email": PropertyRef("service_account")}
+    )
+    direction: LinkDirection = LinkDirection.OUTWARD
+    rel_label: str = "RUNS_AS"
+    properties: GCPGKEClusterToProjectRelProperties = (
+        GCPGKEClusterToProjectRelProperties()
+    )
+
+
+@dataclass(frozen=True)
+class GKENodePoolSchema(CartographyNodeSchema):
+    """A GKE node pool, including the node credential and metadata configuration."""
+
+    label: str = "GKENodePool"
+    properties: GKENodePoolNodeProperties = GKENodePoolNodeProperties()
+    sub_resource_relationship: GCPGKEClusterToProjectRel = GCPGKEClusterToProjectRel()
+    other_relationships: OtherRelationships = OtherRelationships(
+        [
+            GKENodePoolToClusterRel(),
+            GKENodePoolToServiceAccountRel(),
+        ]
+    )

--- a/cartography/models/gcp/gke.py
+++ b/cartography/models/gcp/gke.py
@@ -109,7 +109,7 @@ class GCPGKEClusterNodeProperties(CartographyNodeProperties):
     )
     endpoint: PropertyRef = PropertyRef(
         "endpoint",
-        description="The IP address of the cluster's master endpoint. The endpoint can be accessed from the internet at https://username:password@endpoint/.",
+        description="Legacy master endpoint IP address. Address presence alone does not imply that IP access is enabled.",
     )
     initial_version: PropertyRef = PropertyRef(
         "initial_version", description="The initial Kubernetes version for the cluster."
@@ -151,7 +151,7 @@ class GCPGKEClusterNodeProperties(CartographyNodeProperties):
     exposed_internet: PropertyRef = PropertyRef(
         "exposed_internet",
         extra_index=True,
-        description="Set to `True` if at least among `private_nodes`, `private_endpoint_enabled`, or `master_authorized_networks` are disabled.",
+        description="Set to true when the control plane has an enabled authenticated DNS or public IP endpoint. IAM and network restrictions still apply. Older snapshots use the legacy exposure heuristic.",
     )  # Populated by the GCP_GKE_ASSET_EXPOSURE analysis job.
     private_nodes: PropertyRef = PropertyRef(
         "private_nodes",

--- a/cartography/models/gcp/policy_bindings.py
+++ b/cartography/models/gcp/policy_bindings.py
@@ -39,6 +39,10 @@ class GCPPolicyBindingNodeProperties(CartographyNodeProperties):
         "members",
         description="A list of principal email addresses that are granted the role. The synthetic GCP principals `allUsers` and `allAuthenticatedUsers` are NOT included here; presence of either is reflected in `is_public` instead.",
     )
+    raw_members: PropertyRef = PropertyRef(
+        "raw_members",
+        description="Complete IAM member strings, preserving WIF subjects and principalSet selectors. A selector references identities, not every identity in its pool.",
+    )
     wif_pools: PropertyRef = PropertyRef(
         "wif_pools",
         description="A list of Workload Identity Federation pool resource names (`projects/{N}/locations/global/workloadIdentityPools/{POOL}`) referenced by `principal://` or `principalSet://` members of this binding.",

--- a/cartography/models/gcp/workload_identity.py
+++ b/cartography/models/gcp/workload_identity.py
@@ -23,6 +23,9 @@ class GCPWorkloadIdentityPoolNodeProperties(CartographyNodeProperties):
     name: PropertyRef = PropertyRef(
         "name", extra_index=True, description="Same as `id`."
     )
+    pool_id: PropertyRef = PropertyRef(
+        "pool_id", description="Pool ID without the parent project path."
+    )
     display_name: PropertyRef = PropertyRef(
         "displayName", description="The friendly name of the pool."
     )

--- a/cartography/models/kubernetes/clusterroles.py
+++ b/cartography/models/kubernetes/clusterroles.py
@@ -32,6 +32,10 @@ class KubernetesClusterRoleNodeProperties(CartographyNodeProperties):
         "resource_version",
         description="The resource version of the ClusterRole for optimistic concurrency control.",
     )
+    rules: PropertyRef = PropertyRef(
+        "rules",
+        description="JSON policy rules retaining the coupling between API groups, resources, verbs, resource names and non-resource URLs. Flattened fields alone cannot determine effective access.",
+    )
     api_groups: PropertyRef = PropertyRef(
         "api_groups",
         description='List of API groups that this ClusterRole grants access to (e.g. `["core", "apps"]`).',

--- a/cartography/models/kubernetes/clusters.py
+++ b/cartography/models/kubernetes/clusters.py
@@ -33,6 +33,26 @@ class KubernetesClusterNodeProperties(CartographyNodeProperties):
         extra_index=True,
         description="Identifier for the cluster fetched from the kubeconfig context. For EKS clusters this should be the `arn`.",
     )
+    service_account_issuer: PropertyRef = PropertyRef(
+        "service_account_issuer",
+        description="Kubernetes ServiceAccount OIDC issuer read from the authenticated API server. This is distinct from external user OIDC login.",
+    )
+    service_account_jwks_uri: PropertyRef = PropertyRef(
+        "service_account_jwks_uri",
+        description="Public signing-key discovery URI advertised by the API server; not fetched by Cartography.",
+    )
+    gke_resource_name: PropertyRef = PropertyRef(
+        "gke_resource_name",
+        extra_index=True,
+        description="Verified GKE resource name, including project, location, and cluster name.",
+    )
+    gke_uid: PropertyRef = PropertyRef(
+        "gke_uid", description="GKE cloud cluster unique identifier."
+    )
+    workload_pool: PropertyRef = PropertyRef(
+        "workload_pool",
+        description="GKE workload identity pool configured on the cluster.",
+    )
     version: PropertyRef = PropertyRef(
         "git_version",
         description="Git version of the Kubernetes cluster (e.g. v1.27.3).",
@@ -85,7 +105,7 @@ class KubernetesClusterNodeProperties(CartographyNodeProperties):
     )
     kubeconfig_tls_configuration_status: PropertyRef = PropertyRef(
         "kubeconfig_tls_configuration_status",
-        description="Derived kubeconfig TLS posture (`valid_config`, `insecure_skip_tls`, `missing_ca_material`, `unknown`).",
+        description="Derived kubeconfig TLS posture (`valid_config`, `insecure_skip_tls`, `missing_ca_material`, `public_ca`, `unknown`).",
     )
     lastupdated: PropertyRef = PropertyRef("lastupdated", set_in_kwargs=True)
 

--- a/cartography/models/kubernetes/gateway_api.py
+++ b/cartography/models/kubernetes/gateway_api.py
@@ -13,6 +13,14 @@ from cartography.models.core.relationships import TargetNodeMatcher
 
 @dataclass(frozen=True)
 class KubernetesGatewayNodeProperties(CartographyNodeProperties):
+    load_balancer_listeners: PropertyRef = PropertyRef(
+        "load_balancer_listeners",
+        description="Declared frontend protocol and port pairs, e.g. TCP:80, used to disambiguate shared load balancer IPs.",
+    )
+    load_balancer_ips: PropertyRef = PropertyRef(
+        "load_balancer_ips",
+        description="Assigned IP addresses from the Kubernetes load balancer status, not requested spec addresses.",
+    )
     id: PropertyRef = PropertyRef("uid", description="UID of the Gateway.")
     name: PropertyRef = PropertyRef(
         "name", extra_index=True, description="Name of the Gateway."

--- a/cartography/models/kubernetes/gke.py
+++ b/cartography/models/kubernetes/gke.py
@@ -1,0 +1,124 @@
+"""Cross-provider relationships derived from GKE and Kubernetes inventory."""
+
+from dataclasses import dataclass
+
+from cartography.models.core.common import PropertyRef
+from cartography.models.core.relationships import CartographyRelProperties
+from cartography.models.core.relationships import CartographyRelSchema
+from cartography.models.core.relationships import LinkDirection
+from cartography.models.core.relationships import make_source_node_matcher
+from cartography.models.core.relationships import make_target_node_matcher
+from cartography.models.core.relationships import SourceNodeMatcher
+from cartography.models.core.relationships import TargetNodeMatcher
+
+
+@dataclass(frozen=True)
+class GKEBridgeMatchLinkProperties(CartographyRelProperties):
+    lastupdated: PropertyRef = PropertyRef("lastupdated", set_in_kwargs=True)
+    _sub_resource_label: PropertyRef = PropertyRef(
+        "_sub_resource_label", set_in_kwargs=True
+    )
+    _sub_resource_id: PropertyRef = PropertyRef("_sub_resource_id", set_in_kwargs=True)
+
+
+@dataclass(frozen=True)
+class GKEClusterMatchLink(CartographyRelSchema):
+    """Maps a cloud cluster to its Kubernetes API inventory, scoped to the cloud resource."""
+
+    source_node_label: str = "GKECluster"
+    source_node_matcher: SourceNodeMatcher = make_source_node_matcher(
+        {"id": PropertyRef("source_id")}
+    )
+    target_node_label: str = "KubernetesCluster"
+    target_node_matcher: TargetNodeMatcher = make_target_node_matcher(
+        {"id": PropertyRef("target_id")}
+    )
+    direction: LinkDirection = LinkDirection.OUTWARD
+    rel_label: str = "MAPS_TO"
+    properties: GKEBridgeMatchLinkProperties = GKEBridgeMatchLinkProperties()
+
+
+@dataclass(frozen=True)
+class GKENodePoolMatchLink(GKEClusterMatchLink):
+    """Maps a registered node to the GKE node pool named in its labels."""
+
+    source_node_label: str = "KubernetesNode"
+    target_node_label: str = "GKENodePool"
+    rel_label: str = "MEMBER_OF"
+
+
+@dataclass(frozen=True)
+class GKEPoolMatchLink(GKEClusterMatchLink):
+    """Identifies the Google-managed workload pool configured on a cluster."""
+
+    target_node_label: str = "GCPWorkloadIdentityPool"
+    rel_label: str = "USES_WORKLOAD_IDENTITY_POOL"
+
+
+@dataclass(frozen=True)
+class GKEPolicyEvidenceMatchLinkProperties(GKEBridgeMatchLinkProperties):
+    matched_members: PropertyRef = PropertyRef(
+        "matched_members",
+        description="Exact IAM members matching this Kubernetes identity.",
+    )
+    policy_lastupdated: PropertyRef = PropertyRef(
+        "policy_lastupdated",
+        description="Timestamp of the IAM policy snapshot used for this relationship.",
+    )
+
+
+@dataclass(frozen=True)
+class GKEWorkloadPolicyMatchLink(GKEClusterMatchLink):
+    """Matches a KSA to an IAM allow binding; conditions remain on the binding and are not evaluated."""
+
+    source_node_label: str = "KubernetesServiceAccount"
+    target_node_label: str = "GCPPolicyBinding"
+    rel_label: str = "HAS_ALLOW_POLICY"
+    properties: GKEPolicyEvidenceMatchLinkProperties = (
+        GKEPolicyEvidenceMatchLinkProperties()
+    )
+
+
+@dataclass(frozen=True)
+class GKEWorkloadImpersonationMatchLink(GKEWorkloadPolicyMatchLink):
+    """Links an annotated KSA to a GSA with an unconditional workloadIdentityUser grant. Runtime access also depends on GKE configuration and other policy controls."""
+
+    target_node_label: str = "GCPServiceAccount"
+    target_node_matcher: TargetNodeMatcher = make_target_node_matcher(
+        {"email": PropertyRef("target_id")}
+    )
+    rel_label: str = "WORKLOAD_IDENTITY_BINDING"
+
+
+@dataclass(frozen=True)
+class GKEUserMatchLink(GKEClusterMatchLink):
+    """Maps an inventoried Google principal email to an exact Kubernetes RBAC User subject."""
+
+    source_node_label: str = "GCPPrincipal"
+    source_node_matcher: SourceNodeMatcher = make_source_node_matcher(
+        {"email": PropertyRef("source_id")}
+    )
+    target_node_label: str = "KubernetesUser"
+
+
+@dataclass(frozen=True)
+class GKEServiceLoadBalancerMatchLink(GKEClusterMatchLink):
+    """Correlates a Service status address with a project and network scoped GCP forwarding rule."""
+
+    source_node_label: str = "KubernetesService"
+    target_node_label: str = "GCPForwardingRule"
+    rel_label: str = "USES_LOAD_BALANCER"
+
+
+@dataclass(frozen=True)
+class GKEIngressLoadBalancerMatchLink(GKEServiceLoadBalancerMatchLink):
+    """Correlates an Ingress status address with a scoped GCP forwarding rule."""
+
+    source_node_label: str = "KubernetesIngress"
+
+
+@dataclass(frozen=True)
+class GKEGatewayLoadBalancerMatchLink(GKEServiceLoadBalancerMatchLink):
+    """Correlates a Gateway status address with a scoped GCP forwarding rule."""
+
+    source_node_label: str = "KubernetesGateway"

--- a/cartography/models/kubernetes/ingress.py
+++ b/cartography/models/kubernetes/ingress.py
@@ -13,6 +13,10 @@ from cartography.models.core.relationships import TargetNodeMatcher
 
 @dataclass(frozen=True)
 class KubernetesIngressNodeProperties(CartographyNodeProperties):
+    load_balancer_ips: PropertyRef = PropertyRef(
+        "load_balancer_ips",
+        description="Assigned IP addresses from the Kubernetes load balancer status, not requested spec addresses.",
+    )
     id: PropertyRef = PropertyRef("uid", description="UID of the Kubernetes Ingress.")
     name: PropertyRef = PropertyRef(
         "name", description="Name of the Kubernetes Ingress."

--- a/cartography/models/kubernetes/nodes.py
+++ b/cartography/models/kubernetes/nodes.py
@@ -63,6 +63,14 @@ class KubernetesNodeNodeProperties(CartographyNodeProperties):
         extra_index=True,
         description="EC2 instance id parsed from `provider_id` for EKS nodes (e.g. `i-0123456789abcdef0`); null for non-AWS providers.",
     )
+    gcp_instance_id: PropertyRef = PropertyRef(
+        "gcp_instance_id",
+        description="Canonical Compute Engine resource ID parsed from the node providerID. Autopilot VMs may not be visible in Compute inventory.",
+    )
+    gke_node_pool: PropertyRef = PropertyRef(
+        "gke_node_pool",
+        description="GKE node pool name from the cloud.google.com/gke-nodepool label.",
+    )
     labels: PropertyRef = PropertyRef(
         "labels",
         description="Node metadata labels stored as a JSON-encoded object.",
@@ -135,6 +143,16 @@ class KubernetesNodeToEC2InstanceRel(CartographyRelSchema):
 
 
 @dataclass(frozen=True)
+class KubernetesNodeToGCPInstanceRel(KubernetesNodeToEC2InstanceRel):
+    """Links a Kubernetes node to an inventoried Compute Engine VM by providerID."""
+
+    target_node_label: str = "GCPInstance"
+    target_node_matcher: TargetNodeMatcher = make_target_node_matcher(
+        {"id": PropertyRef("gcp_instance_id")}
+    )
+
+
+@dataclass(frozen=True)
 class KubernetesNodeSchema(CartographyNodeSchema):
     "A worker node registered with a Kubernetes cluster."
 
@@ -146,5 +164,6 @@ class KubernetesNodeSchema(CartographyNodeSchema):
     other_relationships: OtherRelationships = OtherRelationships(
         [
             KubernetesNodeToEC2InstanceRel(),
+            KubernetesNodeToGCPInstanceRel(),
         ]
     )

--- a/cartography/models/kubernetes/roles.py
+++ b/cartography/models/kubernetes/roles.py
@@ -32,6 +32,10 @@ class KubernetesRoleNodeProperties(CartographyNodeProperties):
         "resource_version",
         description="The resource version of the Role for optimistic concurrency control.",
     )
+    rules: PropertyRef = PropertyRef(
+        "rules",
+        description="JSON policy rules retaining the coupling between API groups, resources, verbs, resource names and non-resource URLs. Flattened fields alone cannot determine effective access.",
+    )
     api_groups: PropertyRef = PropertyRef(
         "api_groups",
         description='List of API groups that this Role grants access to (e.g. `["core", "apps"]`).',

--- a/cartography/models/kubernetes/serviceaccounts.py
+++ b/cartography/models/kubernetes/serviceaccounts.py
@@ -124,14 +124,14 @@ class KubernetesServiceAccountToGCPServiceAccountRelProperties(
 
 @dataclass(frozen=True)
 class KubernetesServiceAccountToGCPServiceAccountRel(CartographyRelSchema):
-    """Links a service account to the Google Cloud service account it impersonates through Workload Identity."""
+    """Records the GCP service account annotation; this alone does not establish impersonation permission."""
 
     target_node_label: str = "GCPServiceAccount"
     target_node_matcher: TargetNodeMatcher = make_target_node_matcher(
         {"email": PropertyRef("gcp_service_account")}
     )
     direction: LinkDirection = LinkDirection.OUTWARD
-    rel_label: str = "WORKLOAD_IDENTITY_BINDING"
+    rel_label: str = "ANNOTATED_SERVICE_ACCOUNT"
     properties: KubernetesServiceAccountToGCPServiceAccountRelProperties = (
         KubernetesServiceAccountToGCPServiceAccountRelProperties()
     )

--- a/cartography/models/kubernetes/services.py
+++ b/cartography/models/kubernetes/services.py
@@ -13,6 +13,14 @@ from cartography.models.core.relationships import TargetNodeMatcher
 
 @dataclass(frozen=True)
 class KubernetesServiceNodeProperties(CartographyNodeProperties):
+    load_balancer_listeners: PropertyRef = PropertyRef(
+        "load_balancer_listeners",
+        description="Declared frontend protocol and port pairs, e.g. TCP:80, used to disambiguate shared load balancer IPs.",
+    )
+    load_balancer_ips: PropertyRef = PropertyRef(
+        "load_balancer_ips",
+        description="Assigned IP addresses from the Kubernetes load balancer status, not requested spec addresses.",
+    )
     id: PropertyRef = PropertyRef("uid", description="UID of the kubernetes service.")
     name: PropertyRef = PropertyRef(
         "name", extra_index=True, description="Name of the kubernetes service."

--- a/cartography/models/ontology/mapping/data/clusters.py
+++ b/cartography/models/ontology/mapping/data/clusters.py
@@ -182,12 +182,10 @@ gcp_gke_mapping = OntologyMapping(
                     special_handling="mapping",
                     extra={"map": _GCP_GKE_STATUS},
                 ),
-                # privateClusterConfig.enablePrivateEndpoint=true means the master is only
-                # reachable from its internal IP, so its inverse encodes "public endpoint reachable".
+                # Includes authenticated DNS access and respects disabled IP endpoints.
                 OntologyFieldMapping(
                     ontology_field="control_plane_public_access",
-                    node_field="private_endpoint_enabled",
-                    special_handling="invert_boolean",
+                    node_field="control_plane_public_access",
                 ),
             ],
         ),

--- a/docs/root/modules/kubernetes/config.md
+++ b/docs/root/modules/kubernetes/config.md
@@ -287,7 +287,9 @@ the same graph, provided GCP inventory is available before Kubernetes enrichment
   Named identities and namespace sets intentionally span clusters in the same pool.
 - `ANNOTATED_SERVICE_ACCOUNT` records the GSA annotation. A
   `WORKLOAD_IDENTITY_BINDING` additionally requires a matching **unconditional**
-  `roles/iam.workloadIdentityUser` binding applying to that GSA. Conditional grants
+  `roles/iam.workloadIdentityUser` binding attached directly to that GSA. Inherited
+  project/folder/organization grants remain visible as policy paths but are not
+  expanded into impersonation edges. Conditional grants
   remain traversable through policy nodes; CEL conditions are not evaluated.
   Previous annotation-only `WORKLOAD_IDENTITY_BINDING` edges are removed after a successful Kubernetes RBAC sync. Queries relying on the old
   annotation semantics should migrate to `ANNOTATED_SERVICE_ACCOUNT`.

--- a/docs/root/modules/kubernetes/config.md
+++ b/docs/root/modules/kubernetes/config.md
@@ -216,3 +216,91 @@ after a successful sync.
 
 - [Kubernetes kubeconfig documentation](https://kubernetes.io/docs/concepts/configuration/organize-cluster-access-kubeconfig/)
 - [Amazon EKS access entries](https://docs.aws.amazon.com/eks/latest/userguide/access-entries.html)
+
+## GKE: Google credentials without kubeconfig
+
+Use Application Default Credentials (ADC), including attached service accounts,
+federated credentials, or local `gcloud auth application-default login` credentials:
+
+```bash
+cartography --neo4j-uri bolt://localhost:7687 \
+  --selected-modules kubernetes \
+  --gke-cluster projects/example-project/locations/us-central1/clusters/example \
+  --gke-impersonate-service-account cartography@example-project.iam.gserviceaccount.com
+```
+
+Repeat `--gke-cluster` to select additional clusters. It accepts canonical resource
+names, GKE selfLinks, or `gke_PROJECT_LOCATION_NAME` context identifiers. Bare
+cluster names are rejected. This mode does not discover every cluster or write
+kubeconfig files. Tokens stay in memory and refresh during ingestion.
+
+The default `--gke-endpoint dns` uses Google's public certificate authorities and
+requires DNS access to be enabled. `--gke-endpoint private` uses the private IP and
+cluster CA; the collector must have a network route to that endpoint.
+`--gke-endpoint public` explicitly selects an enabled public IP endpoint and its
+cluster CA. Cartography never falls back between endpoint types or disables TLS
+verification. Allocated public IP addresses do not establish that IP access is enabled.
+
+For an existing kubeconfig, use `--managed-kubernetes gke`; each context's cluster
+reference must identify its GKE project, location, and name. Google credentials
+resolve its cloud metadata while kubeconfig continues to authenticate Kubernetes
+requests. `--gke-impersonate-service-account` affects the Google credential path,
+not kubeconfig's own authentication.
+
+The Google reader needs `container.clusters.get`, `container.clusters.list`, and
+`container.clusters.connect` (included in `roles/container.clusterViewer`).
+Impersonation additionally requires the caller to have
+`iam.serviceAccounts.getAccessToken` on the chosen reader account, normally via
+`roles/iam.serviceAccountTokenCreator`. Grant the Kubernetes read permissions above
+through a ClusterRoleBinding whose subject is **kind `User`**, with the Google
+service account email as its name. Cloud cluster discovery permission alone does
+not authorize Kubernetes inventory reads. DNS endpoint access can also be restricted
+by IAM and VPC Service Controls.
+
+Optionally grant `get` on the non-resource URL
+`/.well-known/openid-configuration` to collect the Kubernetes ServiceAccount OIDC
+issuer and advertised JWKS URI. Cartography does not retrieve tokens or follow the
+advertised URI. These fields describe workload token issuance, not external OIDC
+login for human users.
+
+Run the GCP module first with GKE, IAM, workload identity pools, policy bindings,
+and Compute forwarding rules enabled. The native reader options only select the
+identity used for GKE discovery and Kubernetes; they do not change the GCP module's
+credentials. See [GCP configuration](../gcp/config.md) for its permission model.
+Google inventory and Kubernetes inventory can be collected in separate runs into
+the same graph, provided GCP inventory is available before Kubernetes enrichment.
+
+### GKE graph semantics
+
+- `GKECluster -[:MAPS_TO]-> KubernetesCluster` links the cloud resource to the
+  observed `kube-system` namespace UID. Cloud names normalize zonal and regional
+  API paths. Recreating a cluster replaces its cloud mapping.
+- `GKECluster -[:HAS_NODE_POOL]-> GKENodePool` records node credentials, OAuth
+  scopes, workload metadata mode, and instance group URLs. Kubernetes nodes link
+  to their pools and to inventoried Compute instances by `gce://` providerID.
+  Autopilot's Compute VMs may be invisible through the Compute API; a missing VM
+  link is not evidence of a missing worker node.
+- `KubernetesServiceAccount -[:HAS_ALLOW_POLICY]-> GCPPolicyBinding` preserves
+  exact matching WIF members and the IAM snapshot timestamp. Supported selectors
+  are namespace/name subjects, ServiceAccount UID subjects, namespace and cluster
+  principal sets, whole-pool sets, and legacy `serviceAccount:POOL[ns/sa]` members.
+  Named identities and namespace sets intentionally span clusters in the same pool.
+- `ANNOTATED_SERVICE_ACCOUNT` records the GSA annotation. A
+  `WORKLOAD_IDENTITY_BINDING` additionally requires a matching **unconditional**
+  `roles/iam.workloadIdentityUser` binding applying to that GSA. Conditional grants
+  remain traversable through policy nodes; CEL conditions are not evaluated.
+  Previous annotation-only `WORKLOAD_IDENTITY_BINDING` edges are removed after a successful Kubernetes RBAC sync. Queries relying on the old
+  annotation semantics should migrate to `ANNOTATED_SERVICE_ACCOUNT`.
+- IAM allow paths are configuration evidence, not proof of successful runtime
+  access. Account status, IAM deny policies, conditions, service perimeters,
+  node metadata mode, host networking, and API-specific restrictions can change
+  the result. Inspect the timestamps of both inventory sources.
+- Services, Ingresses, and Gateways link to GCP forwarding rules using assigned
+  status IPs, the GKE project, and (for internal rules) the full VPC path. Shared
+  VPC host-project network paths are preserved. Backend health and effective
+  firewall reachability are not inferred from this link. Gateway HTTPRoute paths
+  follow accepted attachments already collected by the Gateway API module.
+
+Incomplete GKE discovery preserves existing inventory. Kubernetes node, service,
+ingress, and RBAC list failures fail the cluster sync before their cleanup. Optional
+Gateway API access denial preserves prior gateway links as well as gateway nodes.

--- a/docs/root/modules/kubernetes/queries.md
+++ b/docs/root/modules/kubernetes/queries.md
@@ -46,3 +46,70 @@ RETURN pod.namespace, pod.name, container.name,
        labels(cloud_disk), cloud_disk.id, storage_class.name
 ORDER BY pod.namespace, pod.name, container.name;
 ```
+
+## GKE workload access to Google Cloud
+
+Show IAM allow bindings whose full member selector matches a workload's Kubernetes
+ServiceAccount. Conditions remain on the policy node and require separate evaluation.
+
+```cypher
+MATCH (pod:KubernetesPod)-[:RUNS_AS]->(ksa:KubernetesServiceAccount)
+      -[grant:HAS_ALLOW_POLICY]->(binding:GCPPolicyBinding)
+OPTIONAL MATCH (binding)-[:APPLIES_TO]->(resource)
+RETURN pod.name, ksa.namespace, ksa.name, binding.role,
+       grant.matched_members, binding.condition_expression,
+       grant.policy_lastupdated, labels(resource), resource.id
+```
+
+Find annotations with no verified unconditional impersonation grant in the current
+graph. Missing IAM inventory also produces this result; check collection coverage.
+
+```cypher
+MATCH (ksa:KubernetesServiceAccount)-[:ANNOTATED_SERVICE_ACCOUNT]->(gsa:GCPServiceAccount)
+WHERE NOT (ksa)-[:WORKLOAD_IDENTITY_BINDING]->(gsa)
+RETURN ksa.namespace, ksa.name, gsa.email, ksa.lastupdated
+```
+
+Follow verified impersonation configuration to the Google identity's policy bindings:
+
+```cypher
+MATCH (pod:KubernetesPod)-[:RUNS_AS]->(ksa:KubernetesServiceAccount)
+      -[:WORKLOAD_IDENTITY_BINDING]->(gsa:GCPServiceAccount)
+MATCH (principal:GCPPrincipal {email: gsa.email})-[:HAS_ALLOW_POLICY]->(binding:GCPPolicyBinding)
+RETURN pod.name, ksa.name, gsa.email, binding.role, binding.condition_expression
+```
+
+## GKE load balancer paths
+
+Show forwarding rules correlated with Services, Ingresses, and Gateways. An internal
+forwarding rule is not internet exposure; external scheme alone does not prove
+backend health or firewall reachability.
+
+```cypher
+MATCH (entry)-[:USES_LOAD_BALANCER]->(lb:GCPForwardingRule)
+RETURN labels(entry), entry.namespace, entry.name,
+       lb.name, lb.ip_address, lb.load_balancing_scheme, lb.network
+```
+
+Follow a Gateway through an accepted HTTPRoute to workloads and their cloud identities:
+
+```cypher
+MATCH (lb:GCPForwardingRule)<-[:USES_LOAD_BALANCER]-(gw:KubernetesGateway)
+      -[:ROUTES]->(:KubernetesHTTPRoute)-[:TARGETS]->(:KubernetesService)
+      -[:TARGETS]->(pod:KubernetesPod)-[:RUNS_AS]->(ksa:KubernetesServiceAccount)
+RETURN lb.name, lb.load_balancing_scheme, gw.name, pod.name, ksa.name
+```
+
+## GKE node credential configuration
+
+```cypher
+MATCH (cloud:GKECluster)-[:MAPS_TO]->(cluster:KubernetesCluster)
+      -[:RESOURCE]->(node:KubernetesNode)-[:MEMBER_OF]->(pool:GKENodePool)
+OPTIONAL MATCH (pool)-[:RUNS_AS]->(account:GCPServiceAccount)
+RETURN cloud.name, cloud.autopilot_enabled, node.name,
+       pool.workload_metadata_mode, pool.oauth_scopes, account.email
+```
+
+`GCE_METADATA` and `GKE_METADATA` distinguish node metadata modes. This query describes
+node configuration, not whether every pod can obtain those node credentials; host
+networking and GKE version-specific behavior also matter.

--- a/tests/integration/cartography/intel/gcp/test_policy_bindings.py
+++ b/tests/integration/cartography/intel/gcp/test_policy_bindings.py
@@ -848,3 +848,59 @@ def test_sync_gcp_policy_bindings_permission_denied(
         == cartography.intel.gcp.policy_bindings.PolicyBindingsSyncStatus.SKIPPED_PERMISSION_DENIED
     )
     mock_get_policy_bindings.assert_called_once()
+
+
+def test_service_account_email_and_numeric_policy_targets(neo4j_session):
+    # Arrange: split loader phase validates both provider representations of the same GSA.
+    neo4j_session.run("MATCH (n) DETACH DELETE n")
+    _create_test_project(neo4j_session)
+    account_id = "111122223333444455556"
+    email = "workload@project-abc.iam.gserviceaccount.com"
+    cartography.intel.gcp.iam.load_gcp_service_accounts(
+        neo4j_session,
+        [{"id": account_id, "uniqueId": account_id, "email": email}],
+        TEST_PROJECT_ID,
+        1,
+    )
+    bindings = [
+        {
+            "id": f"binding-{i}",
+            "resource": f"//iam.googleapis.com/projects/{TEST_PROJECT_ID}/serviceAccounts/{target}",
+            "role": "roles/iam.workloadIdentityUser",
+        }
+        for i, target in enumerate([account_id, email])
+    ]
+    # Act
+    cartography.intel.gcp.policy_bindings.load_bindings(
+        neo4j_session, bindings, TEST_PROJECT_ID, 1
+    )
+    # Assert
+    assert check_nodes(neo4j_session, "GCPServiceAccount", ["id", "email"]) == {
+        (account_id, email)
+    }
+    assert check_rels(
+        neo4j_session,
+        "GCPPolicyBinding",
+        "id",
+        "GCPServiceAccount",
+        "id",
+        "APPLIES_TO",
+        rel_direction_right=True,
+    ) == {("binding-0", account_id), ("binding-1", account_id)}
+    # Act: keeping only the numeric form removes the stale email-form binding and edge.
+    cartography.intel.gcp.policy_bindings.load_bindings(
+        neo4j_session, bindings[:1], TEST_PROJECT_ID, 2
+    )
+    cartography.intel.gcp.policy_bindings.cleanup(
+        neo4j_session, {"PROJECT_ID": TEST_PROJECT_ID, "UPDATE_TAG": 2}
+    )
+    # Assert
+    assert check_rels(
+        neo4j_session,
+        "GCPPolicyBinding",
+        "id",
+        "GCPServiceAccount",
+        "id",
+        "APPLIES_TO",
+        rel_direction_right=True,
+    ) == {("binding-0", account_id)}

--- a/tests/integration/cartography/intel/kubernetes/test_gke.py
+++ b/tests/integration/cartography/intel/kubernetes/test_gke.py
@@ -1,0 +1,316 @@
+from copy import deepcopy
+from unittest.mock import MagicMock
+
+import pytest
+
+from cartography.intel.gcp.gke import sync_gke_clusters
+from cartography.intel.gcp.policy_bindings import load_bindings
+from cartography.intel.kubernetes.gke import sync
+from tests.integration.util import check_nodes
+from tests.integration.util import check_rels
+
+PROJECT = "example-project"
+RESOURCE = f"projects/{PROJECT}/locations/us-central1/clusters/example"
+CLOUD_ID = "https://container.googleapis.com/v1/" + RESOURCE
+POOL = f"projects/111122223333/locations/global/workloadIdentityPools/{PROJECT}.svc.id.goog"
+NETWORK = f"projects/{PROJECT}/global/networks/example"
+EMAIL = f"workload@{PROJECT}.iam.gserviceaccount.com"
+CLUSTER = {
+    "name": "example",
+    "selfLink": CLOUD_ID,
+    "resource_name": RESOURCE,
+    "networkConfig": {"network": NETWORK},
+    "workloadIdentityConfig": {"workloadPool": f"{PROJECT}.svc.id.goog"},
+    "nodePools": [
+        {
+            "name": "pool",
+            "config": {
+                "serviceAccount": EMAIL,
+                "workloadMetadataConfig": {"mode": "GKE_METADATA"},
+            },
+        }
+    ],
+}
+
+
+@pytest.fixture
+def seeded(neo4j_session):
+    neo4j_session.run("MATCH (n) DETACH DELETE n")
+    neo4j_session.run(
+        "CREATE (:GCPProject {id: $project}), (:GCPServiceAccount {id: 'gsa', email: $email}), (:GCPWorkloadIdentityPool {id: $pool, pool_id: $pool_name, project_id: $project})",
+        project=PROJECT,
+        email=EMAIL,
+        pool=POOL,
+        pool_name=f"{PROJECT}.svc.id.goog",
+    )
+    api = MagicMock()
+    api.projects.return_value.locations.return_value.clusters.return_value.list.return_value.execute.return_value = {
+        "clusters": [deepcopy(CLUSTER)]
+    }
+    sync_gke_clusters(
+        neo4j_session, api, PROJECT, 1, {"PROJECT_ID": PROJECT, "UPDATE_TAG": 1}
+    )
+    neo4j_session.run(
+        "CREATE (c:KubernetesCluster {id: 'cluster'}), (other:KubernetesCluster {id: 'other'}), (recreated:KubernetesCluster {id: 'recreated'}) WITH c CREATE (c)-[:RESOURCE]->(:KubernetesNode {id: 'node', gke_node_pool: 'pool', lastupdated: 1})"
+    )
+    neo4j_session.run(
+        "MATCH (c:KubernetesCluster {id: 'cluster'}) UNWIND ['direct', 'linked', 'annotation-only'] AS name CREATE (c)-[:RESOURCE]->(s:KubernetesServiceAccount {id: name, name: name, namespace: 'ns', uid: name + '-uid', lastupdated: 1}) SET s.gcp_service_account = CASE WHEN name <> 'direct' THEN $email ELSE null END",
+        email=EMAIL,
+    )
+    load_bindings(
+        neo4j_session,
+        [
+            {
+                "id": "direct-binding",
+                "role": "roles/storage.objectViewer",
+                "resource": "//storage.googleapis.com/buckets/example-bucket",
+                "raw_members": [
+                    f"principal://iam.googleapis.com/{POOL}/subject/ns/ns/sa/direct"
+                ],
+                "wif_pools": [POOL],
+                "has_condition": False,
+            },
+            {
+                "id": "impersonation-binding",
+                "role": "roles/iam.workloadIdentityUser",
+                "resource": f"//iam.googleapis.com/projects/{PROJECT}/serviceAccounts/{EMAIL}",
+                "raw_members": [f"serviceAccount:{PROJECT}.svc.id.goog[ns/linked]"],
+                "has_condition": False,
+            },
+        ],
+        PROJECT,
+        1,
+    )
+    neo4j_session.run(
+        "MATCH (s:KubernetesServiceAccount {id: 'annotation-only'}), (g:GCPServiceAccount) CREATE (s)-[:WORKLOAD_IDENTITY_BINDING {lastupdated: 0}]->(g)"
+    )
+    neo4j_session.run(
+        "MATCH (c:KubernetesCluster {id: 'cluster'}) CREATE (c)-[:RESOURCE]->(:KubernetesService {id: 'svc', load_balancer_ips: ['10.0.0.2'], lastupdated: 1}), (c)-[:RESOURCE]->(:KubernetesIngress {id: 'ing', load_balancer_ips: ['10.0.0.2'], lastupdated: 1}), (c)-[:RESOURCE]->(:KubernetesGateway {id: 'gateway', load_balancer_ips: ['10.0.0.2'], lastupdated: 1}), (:GCPForwardingRule {id: 'lb', ip_address: '10.0.0.2', project_id: $project, network: $network, load_balancing_scheme: 'INTERNAL'})",
+        project=PROJECT,
+        network=NETWORK,
+    )
+    return neo4j_session, api
+
+
+def test_gke_bridge_and_annotation_evidence(seeded):
+    # Arrange
+    session, _ = seeded
+    # Act
+    sync(session, CLUSTER, "cluster", 1)
+    # Assert
+    assert check_nodes(session, "GKENodePool", ["id", "workload_metadata_mode"]) == {
+        (RESOURCE + "/nodePools/pool", "GKE_METADATA")
+    }
+    assert check_rels(
+        session,
+        "GKECluster",
+        "id",
+        "KubernetesCluster",
+        "id",
+        "MAPS_TO",
+        rel_direction_right=True,
+    ) == {(CLOUD_ID, "cluster")}
+    assert check_rels(
+        session,
+        "KubernetesServiceAccount",
+        "id",
+        "GCPPolicyBinding",
+        "id",
+        "HAS_ALLOW_POLICY",
+        rel_direction_right=True,
+    ) == {("direct", "direct-binding"), ("linked", "impersonation-binding")}
+    assert check_rels(
+        session,
+        "KubernetesServiceAccount",
+        "id",
+        "GCPServiceAccount",
+        "email",
+        "WORKLOAD_IDENTITY_BINDING",
+        rel_direction_right=True,
+    ) == {("linked", EMAIL)}
+    assert check_rels(
+        session,
+        "KubernetesNode",
+        "id",
+        "GKENodePool",
+        "id",
+        "MEMBER_OF",
+        rel_direction_right=True,
+    ) == {("node", RESOURCE + "/nodePools/pool")}
+    for label, id_ in [
+        ("KubernetesService", "svc"),
+        ("KubernetesIngress", "ing"),
+        ("KubernetesGateway", "gateway"),
+    ]:
+        assert check_rels(
+            session,
+            label,
+            "id",
+            "GCPForwardingRule",
+            "id",
+            "USES_LOAD_BALANCER",
+            rel_direction_right=True,
+        ) == {(id_, "lb")}
+
+
+def test_removed_grants_addresses_and_cluster_recreation_cleanup(seeded):
+    # Arrange
+    session, _ = seeded
+    sync(session, CLUSTER, "cluster", 1)
+    session.run("MATCH (b:GCPPolicyBinding) SET b.raw_members = [], b.lastupdated = 2")
+    session.run(
+        "MATCH (:KubernetesCluster {id: 'cluster'})-[:RESOURCE]->(n) SET n.lastupdated = 2, n.load_balancer_ips = []"
+    )
+    session.run(
+        "MATCH (c:KubernetesCluster {id: 'other'}), (lb:GCPForwardingRule) CREATE (c)-[:RESOURCE]->(s:KubernetesService {id: 'other-svc'}), (s)-[:USES_LOAD_BALANCER {_sub_resource_label: 'KubernetesCluster', _sub_resource_id: 'other', lastupdated: 1}]->(lb)"
+    )
+    # Act
+    sync(session, CLUSTER, "cluster", 2)
+    sync(session, CLUSTER, "recreated", 2)
+    # Assert
+    assert check_rels(
+        session,
+        "GKECluster",
+        "id",
+        "KubernetesCluster",
+        "id",
+        "MAPS_TO",
+        rel_direction_right=True,
+    ) == {(CLOUD_ID, "recreated")}
+    assert (
+        check_rels(
+            session,
+            "KubernetesServiceAccount",
+            "id",
+            "GCPServiceAccount",
+            "email",
+            "WORKLOAD_IDENTITY_BINDING",
+            rel_direction_right=True,
+        )
+        == set()
+    )
+    assert check_rels(
+        session,
+        "KubernetesService",
+        "id",
+        "GCPForwardingRule",
+        "id",
+        "USES_LOAD_BALANCER",
+        rel_direction_right=True,
+    ) == {("other-svc", "lb")}
+
+
+def test_gateway_denied_preserves_links(seeded):
+    # Arrange
+    session, _ = seeded
+    sync(session, CLUSTER, "cluster", 1)
+    # Act
+    sync(session, CLUSTER, "cluster", 2, gateway_complete=False)
+    # Assert
+    assert check_rels(
+        session,
+        "KubernetesGateway",
+        "id",
+        "GCPForwardingRule",
+        "id",
+        "USES_LOAD_BALANCER",
+        rel_direction_right=True,
+    ) == {("gateway", "lb")}
+
+
+def test_cloud_incomplete_preserves_but_empty_cleans(seeded):
+    # Arrange
+    session, api = seeded
+    api.projects.return_value.locations.return_value.clusters.return_value.list.return_value.execute.return_value = {
+        "clusters": [],
+        "missingZones": ["us-central1-a"],
+    }
+    # Act and assert
+    with pytest.raises(RuntimeError):
+        sync_gke_clusters(
+            session, api, PROJECT, 2, {"PROJECT_ID": PROJECT, "UPDATE_TAG": 2}
+        )
+    assert check_nodes(session, "GKECluster", ["id"]) == {(CLOUD_ID,)}
+    # Arrange
+    api.projects.return_value.locations.return_value.clusters.return_value.list.return_value.execute.return_value = (
+        {}
+    )
+    # Act
+    sync_gke_clusters(
+        session, api, PROJECT, 3, {"PROJECT_ID": PROJECT, "UPDATE_TAG": 3}
+    )
+    # Assert
+    assert check_nodes(session, "GKECluster", ["id"]) == set()
+    assert check_nodes(session, "GKENodePool", ["id"]) == set()
+
+
+@pytest.mark.parametrize(
+    "entry", ["KubernetesService", "KubernetesIngress", "KubernetesGateway"]
+)
+def test_gcp_load_balancer_exposure_paths_and_cleanup(seeded, entry):
+    # Arrange
+    from cartography.analysis.kubernetes.analysis import K8S_COMPUTE_ASSET_EXPOSURE_JOBS
+    from cartography.analysis.kubernetes.analysis import K8S_LB_EXPOSURE_JOBS
+    from cartography.util import run_typed_analysis_job
+
+    session, _ = seeded
+    session.run(
+        "MATCH (lb:GCPForwardingRule) SET lb:LoadBalancer, lb.exposed_internet = true"
+    )
+    session.run(
+        "MATCH (c:KubernetesCluster {id: 'cluster'}), (s:KubernetesService {id: 'svc'}) CREATE (c)-[:RESOURCE]->(p:KubernetesPod {id: 'pod'}), (p)-[:CONTAINS]->(:KubernetesContainer {id: 'container'}), (s)-[:TARGETS]->(p)"
+    )
+    session.run(
+        "MATCH (i:KubernetesIngress), (s:KubernetesService {id: 'svc'}), (g:KubernetesGateway), (c:KubernetesCluster {id: 'cluster'}) CREATE (i)-[:TARGETS]->(s), (g)-[:ROUTES]->(r:KubernetesHTTPRoute {id: 'route'}), (c)-[:RESOURCE]->(r), (r)-[:TARGETS]->(s)"
+    )
+    sync(session, CLUSTER, "cluster", 1)
+    session.run(
+        f"MATCH (s)-[r:USES_LOAD_BALANCER]->(:GCPForwardingRule) WHERE NOT s:{entry} DELETE r"
+    )
+    jobs = (*K8S_COMPUTE_ASSET_EXPOSURE_JOBS, *K8S_LB_EXPOSURE_JOBS)
+    # Act
+    for job in jobs:
+        run_typed_analysis_job(job, session, {"UPDATE_TAG": 1, "CLUSTER_ID": "cluster"})
+    # Assert
+    assert check_rels(
+        session,
+        "GCPForwardingRule",
+        "id",
+        "KubernetesPod",
+        "id",
+        "EXPOSE",
+        rel_direction_right=True,
+    ) == {("lb", "pod")}
+    assert check_rels(
+        session,
+        "GCPForwardingRule",
+        "id",
+        "KubernetesContainer",
+        "id",
+        "EXPOSE",
+        rel_direction_right=True,
+    ) == {("lb", "container")}
+    # Arrange: internal / no longer exposed must remove derived exposure on the next tag.
+    session.run("MATCH (lb:GCPForwardingRule) SET lb.exposed_internet = false")
+    # Act
+    for job in jobs:
+        run_typed_analysis_job(job, session, {"UPDATE_TAG": 2, "CLUSTER_ID": "cluster"})
+    # Assert
+    assert (
+        check_rels(
+            session,
+            "GCPForwardingRule",
+            "id",
+            "KubernetesPod",
+            "id",
+            "EXPOSE",
+            rel_direction_right=True,
+        )
+        == set()
+    )
+    assert (
+        session.run(
+            "MATCH (p:KubernetesPod {id: 'pod'}) RETURN coalesce(p.exposed_internet, false) AS exposed"
+        ).single()["exposed"]
+        is False
+    )

--- a/tests/integration/cartography/intel/kubernetes/test_rbac.py
+++ b/tests/integration/cartography/intel/kubernetes/test_rbac.py
@@ -187,7 +187,7 @@ def test_sync_rbac_end_to_end(
         "id",
         "GCPServiceAccount",
         "email",
-        "WORKLOAD_IDENTITY_BINDING",
+        "ANNOTATED_SERVICE_ACCOUNT",
         rel_direction_right=True,
     ) == {
         (

--- a/tests/unit/cartography/intel/gcp/test_gke.py
+++ b/tests/unit/cartography/intel/gcp/test_gke.py
@@ -14,16 +14,10 @@ def _make_http_error(status: int) -> HttpError:
     return HttpError(mock_resp, json.dumps({"error": {"code": status}}).encode())
 
 
-class TestGetGkeClustersCurrentStateSemantics:
-    """
-    Verify current-state semantics for get_gke_clusters.
+class TestGetGkeClustersPartialScanSafety:
+    """Permission failures are unknown inventory, not authoritative emptiness."""
 
-    On permission or API-disabled errors, returning {} (instead of raising) lets
-    the cleanup step remove any previously ingested clusters from the graph, ensuring
-    the graph reflects only the currently visible state.
-    """
-
-    def test_returns_empty_dict_on_forbidden(self):
+    def test_preserves_unknown_on_forbidden(self):
         mock_container = MagicMock()
         with (
             patch(
@@ -35,9 +29,9 @@ class TestGetGkeClustersCurrentStateSemantics:
                 return_value="forbidden",
             ),
         ):
-            assert get_gke_clusters(mock_container, "test-project") == {}
+            assert get_gke_clusters(mock_container, "test-project") is None
 
-    def test_returns_empty_dict_on_api_disabled(self):
+    def test_preserves_unknown_on_api_disabled(self):
         mock_container = MagicMock()
         with (
             patch(
@@ -49,9 +43,9 @@ class TestGetGkeClustersCurrentStateSemantics:
                 return_value="api_disabled",
             ),
         ):
-            assert get_gke_clusters(mock_container, "test-project") == {}
+            assert get_gke_clusters(mock_container, "test-project") is None
 
-    def test_returns_empty_dict_on_billing_disabled(self):
+    def test_preserves_unknown_on_billing_disabled(self):
         mock_container = MagicMock()
         with (
             patch(
@@ -63,7 +57,7 @@ class TestGetGkeClustersCurrentStateSemantics:
                 return_value="billing_disabled",
             ),
         ):
-            assert get_gke_clusters(mock_container, "test-project") == {}
+            assert get_gke_clusters(mock_container, "test-project") is None
 
     def test_reraises_on_unexpected_error(self):
         mock_container = MagicMock()

--- a/tests/unit/cartography/intel/gcp/test_policy_bindings.py
+++ b/tests/unit/cartography/intel/gcp/test_policy_bindings.py
@@ -869,3 +869,18 @@ def test_sync_project_resources_attempts_policy_bindings_without_target_project_
     mock_policy_bindings_sync.assert_called_once()
     mock_permission_relationships_sync.assert_not_called()
     assert result.policy_bindings_cleanup_safe is False
+
+
+def test_gke_members_preserve_selectors_without_fake_email_principals():
+    # Arrange
+    members = [
+        "serviceAccount:example-project.svc.id.goog[namespace/service-account]",
+        "principal://iam.googleapis.com/projects/111122223333/locations/global/workloadIdentityPools/example-project.svc.id.goog/subject/ns/namespace/sa/service-account",
+    ]
+    data = _policy_results_with_members(members)
+    # Act
+    bindings = policy_bindings.transform_bindings(data)
+    # Assert
+    assert len(bindings) == 1
+    assert bindings[0]["raw_members"] == sorted(members)
+    assert bindings[0]["members"] == []

--- a/tests/unit/cartography/intel/kubernetes/test_gke.py
+++ b/tests/unit/cartography/intel/kubernetes/test_gke.py
@@ -1,0 +1,329 @@
+from unittest.mock import MagicMock
+from unittest.mock import patch
+
+import pytest
+
+from cartography.intel.gcp.gke import get_gke_clusters
+from cartography.intel.gcp.gke import transform_gke_clusters
+from cartography.intel.gcp.gke_utils import instance_id_from_provider_id
+from cartography.intel.gcp.gke_utils import parse_cluster_ref
+from cartography.intel.kubernetes.gke import match_load_balancers
+from cartography.intel.kubernetes.gke import match_workload_policies
+from cartography.intel.kubernetes.gke import principal_members
+from cartography.intel.kubernetes.gke_auth import connect
+from cartography.intel.kubernetes.gke_auth import select_endpoint
+
+RESOURCE = "projects/example-project/locations/us-central1/clusters/example"
+POOL = "projects/111122223333/locations/global/workloadIdentityPools/example-project.svc.id.goog"
+SA = {
+    "id": "cluster/ns/app",
+    "namespace": "ns",
+    "name": "app",
+    "uid": "sa-uid",
+    "gcp_service_account": "app@example-project.iam.gserviceaccount.com",
+}
+
+
+@pytest.mark.parametrize(
+    "reference",
+    [
+        RESOURCE,
+        RESOURCE.replace("locations", "zones"),
+        "https://container.googleapis.com/v1/" + RESOURCE,
+        "gke_example-project_us-central1_example",
+    ],
+)
+def test_cluster_reference(reference):
+    # Act
+    ref = parse_cluster_ref(reference)
+    # Assert
+    assert ref.resource_name == RESOURCE
+
+
+@pytest.mark.parametrize(
+    "reference",
+    [
+        "example",
+        "https://attacker.example/" + RESOURCE,
+        RESOURCE + "/extra",
+        "gke_example",
+        "projects/a/locations/us-central1/clusters/../example",
+    ],
+)
+def test_invalid_cluster_reference(reference):
+    # Act and assert
+    with pytest.raises(ValueError):
+        parse_cluster_ref(reference)
+
+
+def test_compute_provider_id():
+    # Act and assert
+    assert (
+        instance_id_from_provider_id("gce://example-project/us-central1-a/node")
+        == "projects/example-project/zones/us-central1-a/instances/node"
+    )
+    assert instance_id_from_provider_id("aws:///us-east-1a/i-123") is None
+    assert instance_id_from_provider_id(None) is None
+
+
+@pytest.mark.parametrize("selector", sorted(principal_members(SA, POOL, RESOURCE)))
+def test_wif_documented_selectors(selector):
+    # Arrange
+    binding = {
+        "id": "binding",
+        "raw_members": [selector],
+        "role": "roles/storage.objectViewer",
+        "has_condition": False,
+        "lastupdated": 10,
+    }
+    # Act
+    grants, impersonations = match_workload_policies([SA], [binding], POOL, RESOURCE)
+    # Assert
+    assert grants == [
+        {
+            "source_id": SA["id"],
+            "target_id": "binding",
+            "matched_members": [selector],
+            "policy_lastupdated": 10,
+        }
+    ]
+    assert impersonations == []
+
+
+def test_wif_exact_matching_and_conditions():
+    # Arrange
+    subject = f"principal://iam.googleapis.com/{POOL}/subject/ns/ns/sa/app"
+    bindings = [
+        {
+            "id": "good",
+            "raw_members": [subject],
+            "role": "roles/iam.workloadIdentityUser",
+            "service_account_emails": [SA["gcp_service_account"]],
+            "has_condition": False,
+        },
+        {
+            "id": "conditional",
+            "raw_members": [subject],
+            "role": "roles/iam.workloadIdentityUser",
+            "service_account_emails": [SA["gcp_service_account"]],
+            "has_condition": True,
+        },
+        {
+            "id": "wrong-gsa",
+            "raw_members": [subject],
+            "role": "roles/iam.workloadIdentityUser",
+            "service_account_emails": ["other@example-project.iam.gserviceaccount.com"],
+            "has_condition": False,
+        },
+        {"id": "wrong-sa", "raw_members": [subject + "-other"]},
+        {
+            "id": "wrong-project",
+            "raw_members": [subject.replace("111122223333", "444455556666")],
+        },
+        {"id": "pool-only", "wif_pools": [POOL]},
+    ]
+    # Act
+    grants, impersonations = match_workload_policies([SA], bindings, POOL, RESOURCE)
+    # Assert
+    assert {r["target_id"] for r in grants} == {"good", "conditional", "wrong-gsa"}
+    assert len(impersonations) == 1
+    assert impersonations[0]["target_id"] == SA["gcp_service_account"]
+
+
+def test_wif_same_subject_across_clusters_but_uid_and_cluster_selectors_differ():
+    # Arrange
+    other = {**SA, "id": "other/ns/app", "uid": "other-uid"}
+    other_resource = RESOURCE.replace("clusters/example", "clusters/other")
+    # Act
+    shared = principal_members(SA, POOL, RESOURCE) & principal_members(
+        other, POOL, other_resource
+    )
+    # Assert
+    assert len(shared) == 4
+    assert not any(
+        "kubernetes.cluster/" in m or "serviceaccount.uid/" in m for m in shared
+    )
+
+
+def test_lb_project_network_and_status_address():
+    # Arrange
+    resources = [
+        {"id": "svc", "load_balancer_ips": ["10.0.0.2", "2001:db8::1", "invalid"]}
+    ]
+    network = "projects/host-project/global/networks/shared"
+    rules = [
+        {
+            "id": "internal",
+            "ip_address": "10.0.0.2",
+            "project_id": "example-project",
+            "network": network,
+            "load_balancing_scheme": "INTERNAL",
+        },
+        {
+            "id": "wrong-network",
+            "ip_address": "10.0.0.2",
+            "project_id": "example-project",
+            "network": network + "-other",
+            "load_balancing_scheme": "INTERNAL",
+        },
+        {
+            "id": "wrong-project",
+            "ip_address": "10.0.0.2",
+            "project_id": "other",
+            "network": network,
+            "load_balancing_scheme": "INTERNAL",
+        },
+        {
+            "id": "external-v6",
+            "ip_address": "2001:db8:0:0:0:0:0:1",
+            "project_id": "example-project",
+            "load_balancing_scheme": "EXTERNAL_MANAGED",
+        },
+        {"id": "unknown", "ip_address": "10.0.0.2", "project_id": "example-project"},
+    ]
+    # Act
+    result = match_load_balancers(resources, rules, "example-project", network)
+    # Assert
+    assert {r["target_id"] for r in result} == {"internal", "external-v6"}
+    assert {
+        r["target_id"]
+        for r in match_load_balancers(resources, rules, "example-project", None)
+    } == {"external-v6"}
+
+
+def test_endpoint_selection_never_falls_back_to_allocated_ip():
+    # Arrange
+    cluster = {
+        "controlPlaneEndpointsConfig": {
+            "dnsEndpointConfig": {
+                "endpoint": "example.gke.goog",
+                "allowExternalTraffic": True,
+            },
+            "ipEndpointsConfig": {"enabled": False},
+        },
+        "privateClusterConfig": {"publicEndpoint": "192.0.2.1"},
+    }
+    # Act and assert
+    assert select_endpoint(cluster, "dns") == ("https://example.gke.goog", True)
+    with pytest.raises(ValueError, match="disabled"):
+        select_endpoint(cluster, "public")
+    cluster["controlPlaneEndpointsConfig"]["dnsEndpointConfig"][
+        "allowExternalTraffic"
+    ] = False
+    with pytest.raises(ValueError):
+        select_endpoint(cluster, "dns")
+
+
+def test_native_client_initial_token_refresh_and_isolation():
+    # Arrange
+    cluster = {
+        "resource_name": RESOURCE,
+        "controlPlaneEndpointsConfig": {
+            "dnsEndpointConfig": {
+                "endpoint": "example.gke.goog",
+                "allowExternalTraffic": True,
+            }
+        },
+    }
+    credentials = MagicMock(valid=True, token="first")
+    # Act
+    with connect(cluster, credentials) as client:
+        config = client.core.api_client.configuration
+        first = config.auth_settings()["BearerToken"]["value"]
+        credentials.token = "second"
+        second = config.auth_settings()["BearerToken"]["value"]
+        # Assert
+        assert first == "Bearer first"
+        assert second == "Bearer second"
+        assert config.verify_ssl is True
+        assert client.core.api_client is client.rbac.api_client
+        assert (
+            client.tls_diagnostics["kubeconfig_tls_configuration_status"] == "public_ca"
+        )
+
+
+def test_partial_zone_listing_is_not_authoritative():
+    # Arrange
+    api = MagicMock()
+    with patch(
+        "cartography.intel.gcp.gke.gcp_api_execute_with_retry",
+        return_value={"missingZones": ["us-central1-a"]},
+    ):
+        # Act and assert
+        with pytest.raises(RuntimeError, match="incomplete"):
+            get_gke_clusters(api, "example-project")
+
+
+def test_gke_dataplane_and_endpoint_fields():
+    # Arrange
+    cluster = {
+        "name": "example",
+        "selfLink": "https://container.googleapis.com/v1/" + RESOURCE,
+        "networkConfig": {"datapathProvider": "ADVANCED_DATAPATH"},
+        "controlPlaneEndpointsConfig": {"ipEndpointsConfig": {"enabled": False}},
+        "privateClusterConfig": {"publicEndpoint": "192.0.2.1"},
+    }
+    # Act
+    transformed = transform_gke_clusters({"clusters": [cluster]})[0]
+    # Assert
+    assert transformed["network_policy"] == "DATAPLANE_V2"
+    assert transformed["public_ip_endpoint_enabled"] is False
+    assert transformed["resource_name"] == RESOURCE
+
+
+def test_oidc_discovery_reads_raw_json_without_following_jwks_uri():
+    # Arrange
+    from cartography.intel.kubernetes.clusters import get_service_account_oidc
+
+    cluster = {
+        "resource_name": RESOURCE,
+        "controlPlaneEndpointsConfig": {
+            "dnsEndpointConfig": {
+                "endpoint": "example.gke.goog",
+                "allowExternalTraffic": True,
+            }
+        },
+    }
+    response = MagicMock(
+        data=b'{"issuer":"https://issuer.example","jwks_uri":"https://keys.example/jwks","extra":"not-collected"}'
+    )
+    with connect(cluster, MagicMock(valid=True, token="test-token")) as client:
+        with patch.object(
+            client.core.api_client, "request", return_value=response
+        ) as request:
+            # Act
+            result = get_service_account_oidc(client)
+            # Assert
+            assert result == {
+                "issuer": "https://issuer.example",
+                "jwks_uri": "https://keys.example/jwks",
+            }
+            assert request.call_count == 1
+            assert (
+                request.call_args.args[1]
+                == "https://example.gke.goog/.well-known/openid-configuration"
+            )
+            response.release_conn.assert_called_once()
+
+
+def test_shared_vip_disambiguates_protocol_and_port():
+    # Arrange
+    resource = {
+        "id": "service",
+        "load_balancer_ips": ["192.0.2.1"],
+        "load_balancer_listeners": ["TCP:443"],
+    }
+    base = {
+        "project_id": "example-project",
+        "ip_address": "192.0.2.1",
+        "load_balancing_scheme": "EXTERNAL",
+    }
+    rules = [
+        {**base, "id": "https", "ip_protocol": "TCP", "port_range": "443-443"},
+        {**base, "id": "http", "ip_protocol": "TCP", "ports": ["80"]},
+        {**base, "id": "quic", "ip_protocol": "UDP", "ports": ["443"]},
+    ]
+    # Act
+    result = match_load_balancers([resource], rules, "example-project", None)
+    # Assert
+    assert result == [{"source_id": "service", "target_id": "https"}]


### PR DESCRIPTION
### Type of change
- [x] Bug fix (non-breaking change that fixes an issue)
- [x] New feature (non-breaking change that adds functionality)
- [x] Breaking change (fix or feature that would cause existing functionality to change)
- [x] Documentation update

### Summary

Connect GKE cloud inventory to Kubernetes workloads, Google workload identity, and GCP load balancers. Security queries can follow a forwarding rule through a Service, Ingress, or Gateway to pods, their Kubernetes service accounts, and matching Google IAM allow bindings.

- Add opt-in `--gke-cluster` authentication through Google ADC, with refreshable credentials, optional service-account impersonation, and explicit DNS/private/public endpoint selection. DNS uses public CAs; IP endpoints use the cluster CA. No kubeconfig or bearer tokens are written to disk.
- Link GKE clusters, Kubernetes clusters, node pools, node service accounts, and visible Compute instances. Capture Autopilot, workload metadata mode, workload pools, enabled control-plane endpoints, and ServiceAccount OIDC discovery metadata.
- Preserve full IAM member selectors and connect matching KSAs to policy bindings. Handle direct WIF, namespace/name and UID subjects, namespace/cluster/pool principal sets, and legacy GKE service-account members. Retain conditional grants without claiming their conditions are satisfied.
- Distinguish GSA annotations from verified unconditional `workloadIdentityUser` grants. Resolve Cloud Asset service-account policy targets by email or numeric ID; the live API uses both forms.
- Connect assigned load-balancer addresses to project-scoped GCP forwarding rules, requiring matching VPCs for internal addresses. Use frontend protocol/port pairs where available to distinguish shared VIPs. Extend existing exposure analysis to GCP and Gateway HTTPRoute paths.
- Preserve inventory on incomplete GKE discovery and required Kubernetes list failures. Add scoped stale-edge cleanup, complete RBAC rule JSON, documentation, and security query examples.

### Related issues or links

- [GKE Workload Identity Federation](https://cloud.google.com/kubernetes-engine/docs/concepts/workload-identity)
- [GKE control-plane access](https://cloud.google.com/kubernetes-engine/docs/concepts/control-plane-access)

### Breaking changes

`KubernetesServiceAccount -[:WORKLOAD_IDENTITY_BINDING]-> GCPServiceAccount` now requires both the annotation and a matching unconditional IAM grant. Annotation-only queries should use `ANNOTATED_SERVICE_ACCOUNT`. A successful Kubernetes RBAC sync removes legacy unverified edges. Run GCP IAM/workload-pool/policy ingestion before GKE enrichment to establish verified links.

Required node, Service, Ingress, and RBAC list errors now fail the cluster sync instead of cleaning up as though the inventory were empty. Optional Secrets and Gateway API denial still preserves their snapshots.

### How was this tested?

- **5,495 passing tests:** the full unit suite plus Kubernetes integration tests and GCP GKE, workload identity, and policy-binding integration tests. Integration tests used an isolated Testcontainers Neo4j.
- All repository pre-commit checks passed, including mypy. Documentation build passed.
- Live GKE Autopilot with private nodes, DNS-only authenticated API access, no public node addresses, and three internal load-balancer fixtures: Service, Ingress, and Gateway + HTTPRoute. Google Cloud inventory came from real provider APIs, including Cloud Asset policy ingestion.
- Native ADC with reader impersonation completed Kubernetes ingestion into a separate temporary database. The reader had no Secrets permission; no secret nodes were collected.
- Direct WIF and valid GSA impersonation workloads listed a private test bucket with HTTP 200. An identically annotated but unauthorized KSA received HTTP 403 and had no verified impersonation edge.
- Graph assertions confirmed all three forwarding-rule links, the cluster mapping, node-pool links, and the single valid impersonation edge. Removing and restoring the valid KSA annotation removed and restored that edge across live syncs.

Sanitized excerpt from the final live reader sync:

```text
INFO:cartography.intel.kubernetes.rbac:Syncing Kubernetes RBAC resources for cluster gke_example-project_us-central1_example
INFO:cartography.client.core.tx:Loaded 1 (GKECluster)-[MAPS_TO]->(KubernetesCluster) relationships
INFO:cartography.client.core.tx:Loaded 2 (KubernetesNode)-[MEMBER_OF]->(GKENodePool) relationships
INFO:cartography.client.core.tx:Loaded 1 (GKECluster)-[USES_WORKLOAD_IDENTITY_POOL]->(GCPWorkloadIdentityPool) relationships
INFO:cartography.client.core.tx:Loaded 2 (KubernetesServiceAccount)-[HAS_ALLOW_POLICY]->(GCPPolicyBinding) relationships
INFO:cartography.client.core.tx:Loaded 1 (KubernetesServiceAccount)-[WORKLOAD_IDENTITY_BINDING]->(GCPServiceAccount) relationships
INFO:cartography.client.core.tx:Loaded 1 (KubernetesService)-[USES_LOAD_BALANCER]->(GCPForwardingRule) relationships
INFO:cartography.client.core.tx:Loaded 1 (KubernetesIngress)-[USES_LOAD_BALANCER]->(GCPForwardingRule) relationships
INFO:cartography.client.core.tx:Loaded 1 (KubernetesGateway)-[USES_LOAD_BALANCER]->(GCPForwardingRule) relationships
LIVE_ANNOTATION_REMOVAL_CLEANUP_PASSED
LIVE_ANNOTATION_RESTORATION_PASSED
```

### Checklist

#### General
- [x] I have read the contributing guidelines.
- [x] The linter passes locally (`make test_lint` equivalent pre-commit invocation).
- [x] I have added/updated tests that prove the behavior.
- [x] Every commit includes a DCO `Signed-off-by` trailer.

#### Proof of functionality
- [x] New or updated unit/integration tests.

#### Intel connector
- [x] Tested against a real provider environment.
- [x] Included sanitized sync logs and graph assertions.
- [x] Removed credentials and environment identifiers from evidence.

#### Nodes and relationships
- [x] Updated model docstrings and `PropertyRef.description` values.
- [x] Built documentation with `uv run --group doc ./docs/build.sh`.
- [x] Used the declarative data model and scoped MatchLinks.

### Notes for reviewers

The IAM edges represent matching allow-policy configuration, not a complete effective-access solver: CEL conditions, IAM deny policies, service perimeters, node metadata behavior, and runtime restrictions can still affect access. Autopilot Compute VMs may be invisible to the Compute API; Kubernetes node and node-pool inventory remains available. Load-balancer address correlation does not establish backend health or effective firewall reachability. External-LB exposure and negative/scoping cases have integration coverage; live frontends were deliberately internal.
